### PR TITLE
Fix clippy 1.95 lints and unblock the Security Audit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
   audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v4
       - uses: rustsec/audit-check@v2

--- a/crates/vox-capture/src/types.rs
+++ b/crates/vox-capture/src/types.rs
@@ -82,7 +82,7 @@ pub struct StreamInfo {
 
     /// Human-friendly description (e.g., `"Built-in Audio Analog Stereo"`).
     ///
-    /// Sourced from the `node.description` or `node.nick` PipeWire property.
+    /// Sourced from the `node.description` or `node.nick` `PipeWire` property.
     /// Falls back to [`name`](Self::name) if neither is available.
     pub description: Option<String>,
 
@@ -101,7 +101,7 @@ impl StreamInfo {
     ///
     /// Heuristic: media class contains `"Source"` (but not `"Virtual"`) and
     /// the node name does not indicate a monitor or loopback device. This
-    /// avoids selecting PipeWire monitor/loopback nodes that capture system
+    /// avoids selecting `PipeWire` monitor/loopback nodes that capture system
     /// audio rather than the user's voice.
     #[must_use]
     pub fn is_source(&self) -> bool {

--- a/crates/vox-storage/src/store.rs
+++ b/crates/vox-storage/src/store.rs
@@ -159,7 +159,7 @@ impl SessionStore for JsonFileStore {
         }
 
         // Sort newest-first.
-        sessions.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        sessions.sort_by_key(|s| std::cmp::Reverse(s.created_at));
         debug!("listed {} sessions", sessions.len());
         Ok(sessions)
     }

--- a/crates/vox-summarize/src/ollama.rs
+++ b/crates/vox-summarize/src/ollama.rs
@@ -1,6 +1,6 @@
 //! Native Ollama HTTP client.
 //!
-//! Uses Ollama's native `/api/chat` endpoint rather than the OpenAI
+//! Uses Ollama's native `/api/chat` endpoint rather than the `OpenAI`
 //! compatibility layer. This avoids subtle incompatibilities with
 //! `response_format`, `max_tokens`, and the response structure.
 

--- a/crates/vox-transcribe/src/model.rs
+++ b/crates/vox-transcribe/src/model.rs
@@ -146,9 +146,7 @@ pub fn is_model_downloaded(config: &TranscriptionConfig) -> bool {
         return Path::new(&config.model_path).exists();
     }
 
-    ModelSize::from_str(&config.model)
-        .map(|size| default_model_path(size).exists())
-        .unwrap_or(false)
+    ModelSize::from_str(&config.model).is_ok_and(|size| default_model_path(size).exists())
 }
 
 /// Downloads a Whisper model file from Hugging Face and writes it to `dest`.
@@ -166,7 +164,11 @@ pub fn is_model_downloaded(config: &TranscriptionConfig) -> bool {
 /// - failure to create the cache directory
 /// - HTTP request failure or non-200 status
 /// - I/O error while writing the temporary file or renaming it
+#[allow(clippy::too_many_lines)]
 pub fn download_model(size: ModelSize, dest: &Path) -> Result<(), TranscribeError> {
+    // Report progress every 50 MiB.
+    const PROGRESS_INTERVAL_BYTES: u64 = 50 * 1_048_576;
+
     let url = size.download_url();
 
     // Ensure the parent directory exists.
@@ -232,11 +234,10 @@ pub fn download_model(size: ModelSize, dest: &Path) -> Result<(), TranscribeErro
     })?;
 
     let mut downloaded: u64 = 0;
-    // Report progress every 50 MiB.
-    const PROGRESS_INTERVAL_BYTES: u64 = 50 * 1_048_576;
     let mut next_report = PROGRESS_INTERVAL_BYTES;
 
-    let mut buf = [0u8; 65_536]; // 64 KiB read buffer
+    // 64 KiB heap-allocated read buffer (too large for the stack).
+    let mut buf = vec![0u8; 65_536].into_boxed_slice();
     loop {
         use std::io::Read as _;
         let n = response.read(&mut buf).map_err(|e| {

--- a/vox-daemon/src/audio_save.rs
+++ b/vox-daemon/src/audio_save.rs
@@ -70,10 +70,12 @@ pub fn load_wav(path: &Path) -> Result<Vec<f32>> {
         })
         .collect::<Result<Vec<f32>>>()?;
 
+    #[allow(clippy::cast_precision_loss)]
+    let duration_secs = samples.len() as f64 / 16_000.0;
     tracing::info!(
         "loaded {} samples ({:.1}s) from {}",
         samples.len(),
-        samples.len() as f64 / 16_000.0,
+        duration_secs,
         path.display()
     );
 

--- a/vox-daemon/src/main.rs
+++ b/vox-daemon/src/main.rs
@@ -204,7 +204,7 @@ fn list_sources() -> Result<()> {
         return Ok(());
     }
 
-    println!("{:<8} {:<40} {:<16} {}", "Node ID", "Name", "Class", "App");
+    println!("{:<8} {:<40} {:<16} App", "Node ID", "Name", "Class");
     println!("{}", "-".repeat(85));
     for stream in &streams {
         let display_name = stream.description.as_deref().unwrap_or(&stream.name);

--- a/vox-daemon/src/recording.rs
+++ b/vox-daemon/src/recording.rs
@@ -44,7 +44,7 @@ pub async fn record_session(
 
     let mut session = build_session(&config, mic_sample_count, app_sample_count);
 
-    let merged = transcribe_audio(&config, &mut session, mic_chunks, app_chunks)?;
+    let merged = transcribe_audio(&config, &mut session, &mic_chunks, &app_chunks)?;
 
     // Optionally retain the raw audio for later reprocessing.
     if config.storage.retain_audio && !merged.is_empty() {
@@ -342,14 +342,14 @@ fn resolve_source(setting: &str, streams: &[vox_capture::StreamInfo], is_mic: bo
 fn transcribe_audio(
     config: &AppConfig,
     session: &mut Session,
-    mic_chunks: Vec<AudioChunk>,
-    app_chunks: Vec<AudioChunk>,
+    mic_chunks: &[AudioChunk],
+    app_chunks: &[AudioChunk],
 ) -> Result<Vec<f32>> {
     tracing::info!("starting transcription...");
 
     // Log audio diagnostics to help troubleshoot source selection issues.
-    log_audio_diagnostics("mic", &mic_chunks);
-    log_audio_diagnostics("app", &app_chunks);
+    log_audio_diagnostics("mic", mic_chunks);
+    log_audio_diagnostics("app", app_chunks);
 
     #[cfg(feature = "whisper")]
     let transcriber = {
@@ -360,7 +360,7 @@ fn transcribe_audio(
     let transcriber = vox_transcribe::StubTranscriber::new();
 
     // Merge both streams into a single audio buffer and transcribe once.
-    let merged = crate::audio_merge::merge_chunks(&mic_chunks, &app_chunks);
+    let merged = crate::audio_merge::merge_chunks(mic_chunks, app_chunks);
 
     if merged.is_empty() {
         tracing::warn!("no audio to transcribe after merging streams");
@@ -389,7 +389,7 @@ fn transcribe_audio(
     // Run speaker diarization if configured and available.
     #[cfg(feature = "diarize")]
     if config.transcription.diarization_mode == "embedding" {
-        run_diarization(config, session, &merged, &mic_chunks)?;
+        run_diarization(config, session, &merged, mic_chunks)?;
     }
     #[cfg(not(feature = "diarize"))]
     if config.transcription.diarization_mode == "embedding" {
@@ -482,7 +482,7 @@ fn run_diarization(
 
 /// Log diagnostic information about captured audio chunks.
 ///
-/// Helps the user verify that the correct PipeWire nodes were selected and
+/// Helps the user verify that the correct `PipeWire` nodes were selected and
 /// that audio is being captured at a reasonable level.
 #[allow(clippy::cast_precision_loss)]
 fn log_audio_diagnostics(label: &str, chunks: &[AudioChunk]) {


### PR DESCRIPTION
## Summary

- Resolve 9 new clippy error-level lints introduced by stable Rust 1.95.0 so `cargo clippy -- -D warnings` passes again across the workspace.
- Grant `checks: write` to the `audit` job in [.github/workflows/ci.yml](.github/workflows/ci.yml) so `rustsec/audit-check@v2` can post its result via the Checks API. The audit itself already reports `No vulnerabilities were found`; only the check-run API call was failing with `Resource not accessible by integration`.

### Clippy changes

| Lint | Location | Fix |
|---|---|---|
| `doc_markdown` | [crates/vox-capture/src/types.rs](crates/vox-capture/src/types.rs) (x2), [crates/vox-summarize/src/ollama.rs](crates/vox-summarize/src/ollama.rs), [vox-daemon/src/recording.rs:485](vox-daemon/src/recording.rs#L485) | Backtick-wrap `PipeWire` / `OpenAI` in doc comments |
| `unnecessary_sort_by` | [crates/vox-storage/src/store.rs:162](crates/vox-storage/src/store.rs#L162) | Use `sort_by_key(\|s\| std::cmp::Reverse(s.created_at))` |
| `bind_instead_of_map` | [crates/vox-transcribe/src/model.rs:149](crates/vox-transcribe/src/model.rs#L149) | Use `Result::is_ok_and` |
| `items_after_statements` | [crates/vox-transcribe/src/model.rs](crates/vox-transcribe/src/model.rs) | Hoist `PROGRESS_INTERVAL_BYTES` to top of fn |
| `too_many_lines` | [crates/vox-transcribe/src/model.rs:169](crates/vox-transcribe/src/model.rs#L169) | `#[allow]` on `download_model` (inherently long I/O path) |
| `large_stack_arrays` | [crates/vox-transcribe/src/model.rs:239](crates/vox-transcribe/src/model.rs#L239) | Heap-allocate the 64 KiB read buffer |
| `cast_precision_loss` | [vox-daemon/src/audio_save.rs:76](vox-daemon/src/audio_save.rs#L76) | Hoist the `usize as f64` cast with a scoped `#[allow]` |
| `needless_pass_by_value` | [vox-daemon/src/recording.rs:342-346](vox-daemon/src/recording.rs#L342-L346) | Borrow `mic_chunks`/`app_chunks` as slices |
| `print_literal` | [vox-daemon/src/main.rs:207](vox-daemon/src/main.rs#L207) | Inline the `"App"` column header into the format string |

No functional changes.

## Test plan

- [x] `cargo fmt --all --check` clean locally
- [x] `cargo clippy -- -D warnings` clean locally (stable 1.95.0)
- [x] `cargo build` green locally
- [x] `cargo test` green locally (203 tests pass)
- [ ] CI `Check`, `MSRV`, and `Security Audit` jobs green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)