### PR TITLE
docs: sync README and CLAUDE.md with current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Vox Daemon is a Linux-native background service that captures video call audio via PipeWire, transcribes it with Whisper (GPU-accelerated), performs speaker diarization, and generates AI-powered post-call summaries. It is controlled from a system tray icon with a full settings window built in iced.
 
-**Language:** Rust (Edition 2024, stable 1.94.0+)
+**Language:** Rust (Edition 2024, stable 1.85.0+ MSRV)
 **Target Platform:** Linux only (Wayland-first, PipeWire-native)
 **Spec:** See `PRD.md` for the full product requirements document.
 
@@ -22,7 +22,8 @@ vox-daemon/
 ├── crates/
 │   ├── vox-core/           # Shared types, config, error handling, XDG paths
 │   ├── vox-capture/        # PipeWire audio capture
-│   ├── vox-transcribe/     # Whisper integration + diarization
+│   ├── vox-transcribe/     # Whisper speech-to-text integration
+│   ├── vox-diarize/        # Speaker diarization (ONNX speaker embeddings + clustering)
 │   ├── vox-summarize/      # LLM client (built-in, Ollama, OpenAI-compatible)
 │   ├── vox-storage/        # JSON session storage, Markdown export
 │   ├── vox-gui/            # iced settings window + transcript browser
@@ -74,7 +75,9 @@ vox-daemon/
 
 See `PRD.md` Section 10 for full details. Implement in this order:
 
-### Phase 1: Core Audio Pipeline (Current)
+All four phases below have been implemented (commit `50581f1` and subsequent iterations). The lists are retained as a historical roadmap.
+
+### Phase 1: Core Audio Pipeline
 1. Workspace setup with all crate stubs
 2. `vox-core`: Config, error types, XDG paths, shared types
 3. `vox-capture`: PipeWire connection, stream enumeration, audio capture
@@ -148,11 +151,18 @@ Each subagent should write a brief completion summary to a tracking file:
 |---------|-------|---------|
 | PipeWire | `pipewire` | 0.9.2 |
 | Whisper | `whisper-rs` | 0.15.1 |
-| GUI | `iced` | 0.14.0 |
-| System Tray | `tray-icon` | 0.21.2 |
+| ONNX Runtime (diarize) | `ort` | 2.0.0-rc.12 |
+| N-d arrays (diarize) | `ndarray` | 0.16 |
+| GUI | `iced` | 0.14 |
+| File dialog (GUI) | `rfd` | 0.15 |
+| System Tray | `tray-icon` | 0.21 |
+| Tray menu | `muda` | 0.17 |
+| Tray (Linux AppIndicator) | `gtk` | 0.18 (optional) |
 | Notifications | `notify-rust` | 4.11.6 |
 | HTTP Client | `reqwest` | 0.12.x |
 | Async Runtime | `tokio` | 1.x |
+| Async traits | `async-trait` | 0.1 |
+| WAV I/O | `hound` | 3.5 |
 | Serialization | `serde`, `serde_json`, `toml` | 1.x, 1.x, 0.8.x |
 | CLI | `clap` | 4.x |
 | Logging | `tracing`, `tracing-subscriber` | 0.1.x, 0.3.x |

--- a/README.md
+++ b/README.md
@@ -79,11 +79,23 @@ vox-daemon record
 # List past sessions
 vox-daemon list-sessions
 
+# Show the active configuration
+vox-daemon show-config
+
 # Export a session to Markdown
 vox-daemon export <SESSION_ID> > meeting.md
 
 # Summarize a session with your configured LLM
 vox-daemon summarize <SESSION_ID>
+
+# Re-transcribe a session using its retained audio and current settings
+vox-daemon reprocess <SESSION_ID>
+
+# Run the long-lived background service (tray + daemon)
+vox-daemon start
+
+# Launch the settings / transcript browser GUI (requires the `ui` feature)
+vox-daemon gui --page browser
 ```
 
 ## Configuration
@@ -96,15 +108,36 @@ mic_source = "auto"
 app_source = "auto"
 
 [transcription]
-model = "base"           # tiny, base, small, medium, large
-language = "en"
+model = "small"          # tiny, base, small, medium, large
+language = "en"          # or "auto"
 gpu_backend = "auto"     # auto, cuda, rocm, cpu
+model_path = ""          # custom whisper model path, empty = cache dir
+
+# Diarization
+diarization_mode = "none"      # none | embedding (requires `diarize` feature)
+diarize_model_path = ""         # empty = auto-download ECAPA-TDNN ONNX model
+diarize_threshold = 0.5         # cosine distance; lower = more clusters
+enrollment_seconds = 5.0        # seconds of mic-only audio to enroll "You"
+
+# Decoding quality knobs
+decoding_strategy = "beam_search"  # greedy | beam_search
+beam_size = 5
+best_of = 5
+initial_prompt = ""      # seed names / jargon to guide Whisper
+temperature = 0.0
+temperature_inc = 0.2
+entropy_thold = 2.4
+logprob_thold = -1.0
+no_speech_thold = 0.6
 
 [summarization]
-auto_summarize = false
-backend = "ollama"       # ollama, openai_compatible, builtin
+auto_summarize = true
+backend = "builtin"      # builtin, ollama, openai_compatible
 ollama_url = "http://localhost:11434"
 ollama_model = "qwen2.5:1.5b"
+api_url = ""
+api_key = ""
+api_model = ""
 
 [storage]
 data_dir = ""            # empty = XDG default
@@ -129,12 +162,13 @@ Native dependencies are gated behind optional feature flags so the project compi
 | `whisper` | Whisper transcription | `whisper-rs` (builds whisper.cpp) |
 | `cuda` | NVIDIA GPU acceleration | CUDA toolkit |
 | `hipblas` | AMD GPU acceleration | ROCm/hipBLAS |
+| `diarize` | ONNX speaker-embedding diarization | `ort` (ONNX Runtime), auto-downloads an ECAPA-TDNN model |
 | `gtk` | System tray icon | `libgtk-3-dev`, `libayatana-appindicator3-dev` |
-| `ui` | iced settings window | GPU-capable display server |
+| `ui` | iced settings window + transcript browser | GPU-capable display server |
 
 Build with all features:
 ```bash
-cargo build --release --features "pw,whisper,cuda,gtk,ui"
+cargo build --release --features "pw,whisper,cuda,diarize,gtk,ui"
 ```
 
 ## Architecture
@@ -144,7 +178,8 @@ vox-daemon/
 ├── crates/
 │   ├── vox-core/        # Shared types, config, XDG paths
 │   ├── vox-capture/     # PipeWire audio capture
-│   ├── vox-transcribe/  # Whisper integration
+│   ├── vox-transcribe/  # Whisper speech-to-text
+│   ├── vox-diarize/     # Speaker diarization (ONNX embeddings + clustering)
 │   ├── vox-summarize/   # LLM summarization client
 │   ├── vox-storage/     # JSON session storage, Markdown export
 │   ├── vox-gui/         # iced settings window + transcript browser


### PR DESCRIPTION
## Summary
- Adds the `vox-diarize` crate to both architecture trees (it was extracted in commit `5dadbf7` but the docs still described diarization as part of `vox-transcribe`).
- Corrects Rust version claim in CLAUDE.md from `1.94.0+` to the actual MSRV `1.85.0+` (matches `Cargo.toml` and README).
- Marks Phases 1-4 as implemented and retains the lists as a historical roadmap.
- Fills in drift in the README: `diarize` feature flag, expanded `[transcription]` config block (diarization, decoding quality knobs), corrected default model (`small`) and summarization defaults (`auto_summarize = true`, `backend = "builtin"`), and Quick Start entries for `show-config`, `reprocess`, `start`, and `gui`.
- Expands the CLAUDE.md dependency table with `ort`, `ndarray`, `rfd`, `muda`, `gtk`, `async-trait`, and `hound`.

## Test plan
- [ ] Eyeball the rendered README on GitHub for formatting (tables, fenced config block)
- [ ] Confirm the architecture trees still match `ls crates/`
- [ ] Sanity-check `vox-daemon --help` output matches the Quick Start command list

🤖 Generated with [Claude Code](https://claude.com/claude-code)