### PR TITLE
feat(storage): render AI summary above transcript in exports

### DIFF
--- a/crates/vox-storage/src/markdown.rs
+++ b/crates/vox-storage/src/markdown.rs
@@ -43,11 +43,16 @@ pub fn render_with_options(session: &Session, options: &RenderOptions) -> String
     let mut out = String::with_capacity(4096);
 
     render_header(session, &mut out);
-    if options.include_transcript {
-        render_transcript(session, &mut out);
-    }
+
+    let summary_written = options.include_summary && session.summary.is_some();
     if options.include_summary {
         render_summary(session, &mut out);
+    }
+    if options.include_transcript {
+        if summary_written {
+            out.push_str("---\n\n");
+        }
+        render_transcript(session, &mut out);
     }
 
     out
@@ -102,7 +107,7 @@ fn render_summary(session: &Session, out: &mut String) {
         return;
     };
 
-    out.push_str("---\n\n## Summary\n\n");
+    out.push_str("## Summary\n\n");
     out.push_str(&summary.overview);
     out.push_str("\n\n");
 
@@ -406,6 +411,37 @@ mod tests {
         assert!(md.contains("- [ ] Book venue"));
         assert!(md.contains("### Decisions"));
         assert!(md.contains("- Use Rust for the backend."));
+    }
+
+    #[test]
+    fn test_render_summary_above_transcript() {
+        let mut session = base_session();
+        session.transcript = vec![TranscriptSegment {
+            start_time: 0.0,
+            end_time: 5.0,
+            speaker: "You".to_owned(),
+            text: "Transcript body.".to_owned(),
+        }];
+        session.summary = Some(Summary {
+            generated_at: Utc::now(),
+            backend: "ollama".to_owned(),
+            model: "qwen2.5:1.5b".to_owned(),
+            overview: "Summary body.".to_owned(),
+            key_points: vec![],
+            action_items: vec![],
+            decisions: vec![],
+        });
+
+        let md = render(&session);
+        let summary_pos = md.find("## Summary").expect("summary heading");
+        let transcript_pos = md.find("## Transcript").expect("transcript heading");
+        assert!(
+            summary_pos < transcript_pos,
+            "summary should appear above transcript: {md}"
+        );
+        // Divider between summary and transcript is present exactly once after
+        // the header divider.
+        assert_eq!(md.matches("\n---\n\n").count(), 2);
     }
 
     #[test]

--- a/crates/vox-storage/src/text.rs
+++ b/crates/vox-storage/src/text.rs
@@ -16,11 +16,11 @@ pub fn render(session: &Session, options: &RenderOptions) -> String {
     let mut out = String::with_capacity(4096);
 
     render_header(session, &mut out);
-    if options.include_transcript {
-        render_transcript(session, &mut out);
-    }
     if options.include_summary {
         render_summary(session, &mut out);
+    }
+    if options.include_transcript {
+        render_transcript(session, &mut out);
     }
 
     out
@@ -161,6 +161,34 @@ mod tests {
         let txt = render(&session, &RenderOptions::default());
         assert!(txt.contains("[00:10 - 00:20] You:"));
         assert!(txt.contains("Hello."));
+    }
+
+    #[test]
+    fn test_text_render_summary_above_transcript() {
+        let mut session = base_session();
+        session.transcript = vec![TranscriptSegment {
+            start_time: 0.0,
+            end_time: 5.0,
+            speaker: "You".to_owned(),
+            text: "Transcript body.".to_owned(),
+        }];
+        session.summary = Some(Summary {
+            generated_at: Utc::now(),
+            backend: "test".to_owned(),
+            model: "test".to_owned(),
+            overview: "Overview text.".to_owned(),
+            key_points: vec![],
+            action_items: vec![],
+            decisions: vec![],
+        });
+
+        let txt = render(&session, &RenderOptions::default());
+        let summary_pos = txt.find("Summary\n").expect("summary heading");
+        let transcript_pos = txt.find("Transcript\n").expect("transcript heading");
+        assert!(
+            summary_pos < transcript_pos,
+            "summary should appear above transcript: {txt}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- When a session is exported with both the transcript and the AI summary, the summary now appears above the transcript in markdown and plain-text output.
- The `---` divider in markdown moved from `render_summary` to `render_with_options`, so it always sits between sections regardless of ordering (and is only emitted when both sections actually render).
- JSON export is unchanged — `serde_json::Map` orders keys alphabetically by default, so `summary` already precedes `transcript` there.

## Test plan
- [x] `cargo test -p vox-storage --lib` (31 passed, including two new tests locking in summary-above-transcript ordering for both renderers)
- [x] `cargo clippy -p vox-storage --all-targets -- -D warnings` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)