### PR TITLE
feat(export): plugin-based export system with AFFiNE as first target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ vox-daemon/
 │   ├── vox-transcribe/     # Whisper speech-to-text integration
 │   ├── vox-diarize/        # Speaker diarization (ONNX speaker embeddings + clustering)
 │   ├── vox-summarize/      # LLM client (built-in, Ollama, OpenAI-compatible)
+│   ├── vox-export/         # Plugin-based exporter (AFFiNE, future targets)
 │   ├── vox-storage/        # JSON session storage, Markdown export
 │   ├── vox-gui/            # iced settings window + transcript browser
 │   ├── vox-tray/           # System tray icon + popup menu

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +164,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,7 +210,7 @@ dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand",
+ "rand 0.9.2",
  "raw-window-handle",
  "serde",
  "serde_repr",
@@ -204,6 +219,16 @@ dependencies = [
  "wayland-client",
  "wayland-protocols",
  "zbus",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -343,6 +368,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +440,23 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "getrandom 0.2.17",
+ "instant",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -480,6 +544,15 @@ name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block2"
@@ -944,6 +1017,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,6 +1069,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "ctor-lite"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,6 +1089,44 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"
@@ -1015,6 +1145,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -1206,6 +1346,9 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "fdeflate"
@@ -1509,6 +1652,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,8 +1678,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1847,6 +2002,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1945,6 +2106,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1958,6 +2125,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -2004,7 +2172,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2350,6 +2518,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3009,6 +3186,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3871,12 +4058,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3886,7 +4094,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -4012,7 +4229,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -4039,12 +4256,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -4091,6 +4310,53 @@ name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "rust_engineio"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d3572ceba6c5d79eecedf3be93640ca9512fa4100dff6a70f96c514adf4f1f"
+dependencies = [
+ "adler32",
+ "async-stream",
+ "async-trait",
+ "base64 0.21.7",
+ "bytes",
+ "futures-util",
+ "http",
+ "native-tls",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-tungstenite",
+ "tungstenite",
+ "url",
+]
+
+[[package]]
+name = "rust_socketio"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6a8672db895d567b3c0b8a4c0d3e98113ebb32badf6ce66004e743e5ee1e1e"
+dependencies = [
+ "adler32",
+ "async-stream",
+ "backoff",
+ "base64 0.21.7",
+ "bytes",
+ "futures-util",
+ "log",
+ "native-tls",
+ "rand 0.8.6",
+ "rust_engineio",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -4347,6 +4613,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4400,6 +4677,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
 dependencies = [
  "version_check",
+]
+
+[[package]]
+name = "smallstr"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862077b1e764f04c251fe82a2ef562fd78d7cadaeb072ca7c2bcaf7217b1ff3b"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -4911,6 +5197,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5172,6 +5472,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "uds_windows"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5236,7 +5562,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "der",
  "log",
  "native-tls",
@@ -5254,7 +5580,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http",
  "httparse",
  "log",
@@ -5401,6 +5727,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "vox-export"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "reqwest",
+ "rust_socketio",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+ "vox-core",
+ "wiremock",
+ "yrs",
+]
+
+[[package]]
 name = "vox-gui"
 version = "0.1.0"
 dependencies = [
@@ -5414,6 +5760,7 @@ dependencies = [
  "uuid",
  "vox-capture",
  "vox-core",
+ "vox-export",
  "vox-storage",
  "vox-summarize",
 ]
@@ -5605,6 +5952,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -6599,6 +6959,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6798,6 +7181,24 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "yrs"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197c2b4b298f35c3ba4d549884ac872a961112095b29f173ab45e3d5cf609018"
+dependencies = [
+ "arc-swap",
+ "async-lock",
+ "async-trait",
+ "dashmap",
+ "fastrand",
+ "serde",
+ "serde_json",
+ "smallstr",
+ "smallvec",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/vox-transcribe",
     "crates/vox-summarize",
     "crates/vox-storage",
+    "crates/vox-export",
     "crates/vox-diarize",
     "crates/vox-gui",
     "crates/vox-tray",
@@ -52,6 +53,7 @@ vox-capture = { path = "crates/vox-capture" }
 vox-transcribe = { path = "crates/vox-transcribe" }
 vox-summarize = { path = "crates/vox-summarize" }
 vox-storage = { path = "crates/vox-storage" }
+vox-export = { path = "crates/vox-export" }
 vox-gui = { path = "crates/vox-gui" }
 vox-tray = { path = "crates/vox-tray" }
 vox-diarize = { path = "crates/vox-diarize" }

--- a/crates/vox-core/src/config.rs
+++ b/crates/vox-core/src/config.rs
@@ -29,6 +29,10 @@ pub struct AppConfig {
     /// Notification settings.
     #[serde(default)]
     pub notifications: NotificationConfig,
+
+    /// Third-party export target settings.
+    #[serde(default)]
+    pub export: ExportConfig,
 }
 
 impl AppConfig {
@@ -299,6 +303,84 @@ impl Default for NotificationConfig {
     }
 }
 
+/// Third-party export target settings.
+///
+/// Each field here corresponds to one [`vox-export`](../../../vox_export/index.html)
+/// plugin. Adding a new plugin is a matter of adding a new nested config
+/// struct + field here and a new arm in `vox_export::factory::build_targets`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ExportConfig {
+    /// `AFFiNE` (cloud or self-hosted) integration.
+    #[serde(default)]
+    pub affine: AffineExportConfig,
+}
+
+/// `AFFiNE` export integration settings.
+///
+/// Used by `vox_export::affine::AffineTarget`.
+///
+/// # Authentication
+///
+/// `AFFiNE` Cloud (`app.affine.pro`) blocks programmatic email/password
+/// sign-in via Cloudflare; cloud users must generate a personal access
+/// token under `Settings → Integrations → MCP Server` and paste it into
+/// `api_token`. Self-hosted instances additionally accept the
+/// `email` / `password` pair, which is exchanged for a session cookie on
+/// first use.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AffineExportConfig {
+    /// Whether the `AFFiNE` export target is enabled.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Base URL of the `AFFiNE` server (no trailing slash), e.g.
+    /// `https://app.affine.pro` or `https://affine.example.com`.
+    #[serde(default = "default_affine_base_url")]
+    pub base_url: String,
+
+    /// Personal access token (preferred; required for cloud).
+    ///
+    /// Stored in plaintext in `config.toml`; users should `chmod 600` the
+    /// file. Takes precedence over `email`/`password` when set.
+    #[serde(default)]
+    pub api_token: String,
+
+    /// Login email (self-hosted only).
+    #[serde(default)]
+    pub email: String,
+
+    /// Login password (self-hosted only). Stored in plaintext — see the note
+    /// on `api_token`.
+    #[serde(default)]
+    pub password: String,
+
+    /// Optional workspace id to pre-select in the Send-to picker.
+    #[serde(default)]
+    pub default_workspace_id: String,
+
+    /// Optional parent-doc id to pre-select in the Send-to picker.
+    #[serde(default)]
+    pub default_parent_id: String,
+}
+
+impl Default for AffineExportConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            base_url: default_affine_base_url(),
+            api_token: String::new(),
+            email: String::new(),
+            password: String::new(),
+            default_workspace_id: String::new(),
+            default_parent_id: String::new(),
+        }
+    }
+}
+
+fn default_affine_base_url() -> String {
+    "https://app.affine.pro".to_owned()
+}
+
 fn default_auto() -> String {
     "auto".to_owned()
 }
@@ -401,6 +483,28 @@ mic_source = "alsa_input.usb"
         // This test works because the test environment has no XDG config dir set up
         let config = AppConfig::load().expect("should return default");
         assert_eq!(config, AppConfig::default());
+    }
+
+    #[test]
+    fn test_export_config_defaults_to_disabled() {
+        let config = AppConfig::default();
+        assert!(!config.export.affine.enabled);
+        assert_eq!(config.export.affine.base_url, "https://app.affine.pro");
+    }
+
+    #[test]
+    fn test_export_config_partial_toml() {
+        let toml_str = r#"
+[export.affine]
+enabled = true
+api_token = "ut_xyz"
+"#;
+        let config: AppConfig = toml::from_str(toml_str).expect("parse");
+        assert!(config.export.affine.enabled);
+        assert_eq!(config.export.affine.api_token, "ut_xyz");
+        // Unspecified fields keep their defaults.
+        assert_eq!(config.export.affine.base_url, "https://app.affine.pro");
+        assert!(config.export.affine.email.is_empty());
     }
 
     #[test]

--- a/crates/vox-export/Cargo.toml
+++ b/crates/vox-export/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "vox-export"
+description = "Plugin-based exporter for pushing sessions to third-party knowledgebases (Affine, etc.)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+vox-core = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+thiserror = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+async-trait = "0.1"
+base64 = "0.22"
+yrs = "0.23"
+rust_socketio = { version = "0.6", features = ["async"] }
+
+[dev-dependencies]
+tokio = { workspace = true }
+wiremock = "0.6"

--- a/crates/vox-export/src/affine/auth.rs
+++ b/crates/vox-export/src/affine/auth.rs
@@ -1,0 +1,258 @@
+//! `AFFiNE` authentication strategies: bearer token (cloud + self-hosted) or
+//! email/password exchanged for a session cookie (self-hosted only).
+
+use std::sync::Arc;
+
+use reqwest::Client;
+use serde::Serialize;
+use tokio::sync::Mutex;
+use tracing::debug;
+
+use crate::error::ExportError;
+
+/// HTTP / Socket.IO headers produced by [`AuthState::ensure_headers`].
+///
+/// Exactly one of `bearer` / `cookie` is populated at a time.
+#[derive(Debug, Clone, Default)]
+pub struct AuthHeaders {
+    /// Bearer token for `Authorization: Bearer …`.
+    pub bearer: Option<String>,
+    /// Session cookie for `Cookie: …`.
+    pub cookie: Option<String>,
+}
+
+impl AuthHeaders {
+    /// Apply these headers to an outgoing [`reqwest::RequestBuilder`].
+    pub fn apply(&self, mut req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if let Some(b) = &self.bearer {
+            req = req.header("Authorization", format!("Bearer {b}"));
+        }
+        if let Some(c) = &self.cookie {
+            req = req.header("Cookie", c);
+        }
+        req
+    }
+}
+
+#[derive(Debug, Clone)]
+enum AuthMode {
+    Token(String),
+    Password { email: String, password: String },
+}
+
+/// Cached, shared authentication state.
+///
+/// Cloning an [`AuthState`] is cheap and produces a clone that shares the
+/// underlying session cache, so multiple concurrent exports reuse a single
+/// login.
+#[derive(Debug, Clone)]
+pub struct AuthState {
+    mode: AuthMode,
+    /// Cached session cookie for password-based auth. Populated on the first
+    /// [`AuthState::ensure_headers`] call.
+    cookie: Arc<Mutex<Option<String>>>,
+}
+
+impl AuthState {
+    /// Token-based auth — works against cloud and self-hosted.
+    #[must_use]
+    pub fn token(token: String) -> Self {
+        Self {
+            mode: AuthMode::Token(token),
+            cookie: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Email + password auth — self-hosted only.
+    #[must_use]
+    pub fn password(email: String, password: String) -> Self {
+        Self {
+            mode: AuthMode::Password { email, password },
+            cookie: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Return auth headers usable against any endpoint under `base_url`.
+    ///
+    /// For token auth this is trivial; for password auth this performs a
+    /// sign-in round-trip on first use and caches the resulting cookie.
+    ///
+    /// # Errors
+    ///
+    /// - [`ExportError::Auth`] if the sign-in request does not return a
+    ///   `Set-Cookie` header.
+    /// - [`ExportError::Http`] on network failure.
+    /// - [`ExportError::ApiError`] when the server returns a non-2xx status.
+    pub async fn ensure_headers(
+        &self,
+        http: &Client,
+        base_url: &str,
+    ) -> Result<AuthHeaders, ExportError> {
+        match &self.mode {
+            AuthMode::Token(t) => Ok(AuthHeaders {
+                bearer: Some(t.clone()),
+                cookie: None,
+            }),
+            AuthMode::Password { email, password } => {
+                let mut guard = self.cookie.lock().await;
+                if let Some(c) = &*guard {
+                    return Ok(AuthHeaders {
+                        bearer: None,
+                        cookie: Some(c.clone()),
+                    });
+                }
+
+                let cookie = sign_in_password(http, base_url, email, password).await?;
+                *guard = Some(cookie.clone());
+                Ok(AuthHeaders {
+                    bearer: None,
+                    cookie: Some(cookie),
+                })
+            }
+        }
+    }
+
+    /// Force a re-login on next use — call after a 401 response.
+    pub async fn invalidate(&self) {
+        *self.cookie.lock().await = None;
+    }
+}
+
+#[derive(Serialize)]
+struct SignInBody<'a> {
+    email: &'a str,
+    password: &'a str,
+}
+
+/// `POST {base}/api/auth/sign-in` with JSON body; returns the distilled
+/// `Cookie` header string suitable for subsequent requests.
+async fn sign_in_password(
+    http: &Client,
+    base_url: &str,
+    email: &str,
+    password: &str,
+) -> Result<String, ExportError> {
+    let url = format!("{base_url}/api/auth/sign-in");
+    debug!(%url, "POST sign-in");
+    let res = http
+        .post(&url)
+        .json(&SignInBody { email, password })
+        .send()
+        .await?;
+    let status = res.status();
+    if !status.is_success() {
+        let body = res.text().await.unwrap_or_default();
+        return Err(ExportError::Auth(format!(
+            "sign-in returned {}: {}",
+            status.as_u16(),
+            sanitize(&body),
+        )));
+    }
+
+    let cookies: Vec<String> = res
+        .headers()
+        .get_all(reqwest::header::SET_COOKIE)
+        .iter()
+        .filter_map(|h| h.to_str().ok())
+        .map(str::to_owned)
+        .collect();
+    if cookies.is_empty() {
+        return Err(ExportError::Auth(
+            "sign-in returned no Set-Cookie headers".to_owned(),
+        ));
+    }
+
+    let pairs: Vec<String> = cookies
+        .iter()
+        .filter_map(|sc| sc.split(';').next())
+        .map(|p| p.trim().to_owned())
+        .filter(|p| !p.is_empty())
+        .collect();
+    let header = pairs.join("; ");
+    if header.contains(['\r', '\n']) {
+        return Err(ExportError::Auth(
+            "sign-in cookie contained illegal CR/LF characters".to_owned(),
+        ));
+    }
+    Ok(header)
+}
+
+/// Trim HTML and excess whitespace from an API error body so it is safe to
+/// surface in logs / error messages.
+fn sanitize(body: &str) -> String {
+    let mut out = String::with_capacity(body.len());
+    let mut in_tag = false;
+    for ch in body.chars() {
+        match ch {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => out.push(ch),
+            _ => {}
+        }
+    }
+    let collapsed: String = out.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.len() > 200 {
+        format!("{}…", &collapsed[..200])
+    } else {
+        collapsed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn token_headers_are_bearer() {
+        let state = AuthState::token("ut_xyz".to_owned());
+        let http = Client::new();
+        let h = state
+            .ensure_headers(&http, "https://example.com")
+            .await
+            .expect("headers");
+        assert_eq!(h.bearer.as_deref(), Some("ut_xyz"));
+        assert!(h.cookie.is_none());
+    }
+
+    #[test]
+    fn sanitize_strips_tags_and_collapses_ws() {
+        let s = sanitize("<html>  something <b>went</b>\nwrong </html>");
+        assert_eq!(s, "something went wrong");
+    }
+
+    #[test]
+    fn sanitize_truncates_long_bodies() {
+        let long = "x".repeat(500);
+        let s = sanitize(&long);
+        assert!(s.ends_with('…'));
+        assert!(s.len() < long.len());
+    }
+
+    #[test]
+    fn auth_headers_apply_sets_bearer() {
+        let h = AuthHeaders {
+            bearer: Some("tok".to_owned()),
+            cookie: None,
+        };
+        let http = Client::new();
+        let req = h.apply(http.get("https://example.com"));
+        let built = req.build().expect("build");
+        let auth = built.headers().get("Authorization").expect("header");
+        assert_eq!(auth.to_str().unwrap(), "Bearer tok");
+    }
+
+    #[test]
+    fn auth_headers_apply_sets_cookie() {
+        let h = AuthHeaders {
+            bearer: None,
+            cookie: Some("sid=abc".to_owned()),
+        };
+        let http = Client::new();
+        let req = h.apply(http.get("https://example.com"));
+        let built = req.build().expect("build");
+        assert_eq!(
+            built.headers().get("Cookie").unwrap().to_str().unwrap(),
+            "sid=abc"
+        );
+    }
+}

--- a/crates/vox-export/src/affine/graphql.rs
+++ b/crates/vox-export/src/affine/graphql.rs
@@ -112,35 +112,42 @@ struct WorkspaceNode {
     id: String,
 }
 
-/// Fetch all workspaces visible to the authenticated user.
+/// Fetch the ids of all workspaces visible to the authenticated user.
+///
+/// The `AFFiNE` GraphQL schema intentionally does not expose workspace
+/// names — they live in each workspace's root Yjs doc. Callers that want
+/// human-readable names should follow up with a realtime fetch (see
+/// [`super::AffineTarget::list_workspaces`]).
 ///
 /// # Errors
 ///
 /// Returns [`ExportError`] on transport failure or when the GraphQL server
 /// returns an error.
-pub async fn list_workspaces(
+pub async fn list_workspace_ids(
     http: &Client,
     base_url: &str,
     headers: &AuthHeaders,
-) -> Result<Vec<Workspace>, ExportError> {
+) -> Result<Vec<String>, ExportError> {
     let data: WorkspacesData =
         send::<(), _>(http, base_url, headers, WORKSPACES_QUERY, None).await?;
+    Ok(data.workspaces.into_iter().map(|w| w.id).collect())
+}
 
-    // `AFFiNE`'s `workspaces` query returns only ids for security; the display
-    // name lives inside the workspace's own Yjs doc and is not exposed via
-    // GraphQL. Use the short id as the display name so the picker is still
-    // usable.
-    Ok(data
-        .workspaces
-        .into_iter()
-        .map(|w| {
-            let short = w.id.chars().take(8).collect::<String>();
-            Workspace {
-                name: format!("Workspace {short}"),
-                id: w.id,
-            }
-        })
-        .collect())
+/// Short placeholder name for a workspace whose real name could not be
+/// resolved — e.g. the realtime fetch timed out or failed.
+#[must_use]
+pub fn fallback_workspace_name(id: &str) -> String {
+    let short: String = id.chars().take(8).collect();
+    format!("Workspace {short}")
+}
+
+/// Build a [`Workspace`] with a placeholder name derived from its id.
+#[must_use]
+pub fn workspace_with_fallback_name(id: String) -> Workspace {
+    Workspace {
+        name: fallback_workspace_name(&id),
+        id,
+    }
 }
 
 #[derive(Deserialize)]

--- a/crates/vox-export/src/affine/graphql.rs
+++ b/crates/vox-export/src/affine/graphql.rs
@@ -1,0 +1,256 @@
+//! GraphQL client for `AFFiNE` metadata: listing workspaces and docs.
+//!
+//! Only the two queries we need are modelled here; the rest of the `AFFiNE`
+//! schema is ignored. Full schema reference:
+//! <https://github.com/toeverything/AFFiNE/blob/canary/packages/backend/server/src/schema.gql>
+
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+use super::auth::AuthHeaders;
+use crate::{
+    error::ExportError,
+    traits::{Folder, Workspace},
+};
+
+const WORKSPACES_QUERY: &str = r"
+query Workspaces {
+  workspaces {
+    id
+    public
+  }
+}";
+
+const DOCS_QUERY: &str = r"
+query WorkspaceDocs($id: String!, $first: Int!, $offset: Int!) {
+  workspace(id: $id) {
+    id
+    docs(pagination: { first: $first, offset: $offset }) {
+      edges {
+        node {
+          id
+          title
+        }
+      }
+    }
+  }
+}";
+
+/// GraphQL request envelope.
+#[derive(Serialize)]
+struct GqlRequest<'a, V: Serialize> {
+    query: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    variables: Option<V>,
+}
+
+/// GraphQL response envelope — we parse `data` into a type-specific struct
+/// and surface `errors[0].message` as an [`ExportError::ApiError`].
+#[derive(Deserialize)]
+struct GqlResponse<D> {
+    data: Option<D>,
+    #[serde(default = "Vec::new")]
+    errors: Vec<GqlError>,
+}
+
+#[derive(Deserialize)]
+struct GqlError {
+    message: String,
+}
+
+/// Send a GraphQL query and decode its `data` field.
+async fn send<V, D>(
+    http: &Client,
+    base_url: &str,
+    headers: &AuthHeaders,
+    query: &str,
+    variables: Option<V>,
+) -> Result<D, ExportError>
+where
+    V: Serialize,
+    D: for<'de> Deserialize<'de>,
+{
+    let url = format!("{base_url}/graphql");
+    debug!(%url, "POST graphql");
+
+    let req = http.post(&url).json(&GqlRequest { query, variables });
+    let res = headers.apply(req).send().await?;
+    let status = res.status();
+    let body = res.text().await.unwrap_or_default();
+    if !status.is_success() {
+        return Err(ExportError::ApiError {
+            status: status.as_u16(),
+            body,
+        });
+    }
+
+    let parsed: GqlResponse<D> =
+        serde_json::from_str(&body).map_err(|e| ExportError::ParseError {
+            reason: format!("graphql response body did not match expected shape: {e}"),
+        })?;
+
+    if let Some(first) = parsed.errors.into_iter().next() {
+        return Err(ExportError::ApiError {
+            status: 200,
+            body: first.message,
+        });
+    }
+
+    parsed.data.ok_or(ExportError::ParseError {
+        reason: "graphql response had no `data` field".to_owned(),
+    })
+}
+
+#[derive(Deserialize)]
+struct WorkspacesData {
+    workspaces: Vec<WorkspaceNode>,
+}
+
+#[derive(Deserialize)]
+struct WorkspaceNode {
+    id: String,
+}
+
+/// Fetch all workspaces visible to the authenticated user.
+///
+/// # Errors
+///
+/// Returns [`ExportError`] on transport failure or when the GraphQL server
+/// returns an error.
+pub async fn list_workspaces(
+    http: &Client,
+    base_url: &str,
+    headers: &AuthHeaders,
+) -> Result<Vec<Workspace>, ExportError> {
+    let data: WorkspacesData =
+        send::<(), _>(http, base_url, headers, WORKSPACES_QUERY, None).await?;
+
+    // `AFFiNE`'s `workspaces` query returns only ids for security; the display
+    // name lives inside the workspace's own Yjs doc and is not exposed via
+    // GraphQL. Use the short id as the display name so the picker is still
+    // usable.
+    Ok(data
+        .workspaces
+        .into_iter()
+        .map(|w| {
+            let short = w.id.chars().take(8).collect::<String>();
+            Workspace {
+                name: format!("Workspace {short}"),
+                id: w.id,
+            }
+        })
+        .collect())
+}
+
+#[derive(Deserialize)]
+struct DocsData {
+    workspace: DocsWorkspace,
+}
+
+#[derive(Deserialize)]
+struct DocsWorkspace {
+    docs: DocsConnection,
+}
+
+#[derive(Deserialize)]
+struct DocsConnection {
+    edges: Vec<DocsEdge>,
+}
+
+#[derive(Deserialize)]
+struct DocsEdge {
+    node: DocNode,
+}
+
+#[derive(Deserialize)]
+struct DocNode {
+    id: String,
+    #[serde(default)]
+    title: Option<String>,
+}
+
+#[derive(Serialize)]
+struct DocsVariables<'a> {
+    id: &'a str,
+    first: i32,
+    offset: i32,
+}
+
+/// Fetch the first page of docs in `workspace_id`. Returns up to 200 docs —
+/// enough for the Send-to picker; full pagination is not needed.
+///
+/// # Errors
+///
+/// Returns [`ExportError`] on transport or API failure.
+pub async fn list_docs(
+    http: &Client,
+    base_url: &str,
+    headers: &AuthHeaders,
+    workspace_id: &str,
+) -> Result<Vec<Folder>, ExportError> {
+    let vars = DocsVariables {
+        id: workspace_id,
+        first: 200,
+        offset: 0,
+    };
+    let data: DocsData = send(http, base_url, headers, DOCS_QUERY, Some(vars)).await?;
+    Ok(data
+        .workspace
+        .docs
+        .edges
+        .into_iter()
+        .map(|e| Folder {
+            id: e.node.id.clone(),
+            title: e.node.title.unwrap_or_else(|| "Untitled".to_owned()),
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gql_response_parses_errors() {
+        let body = r#"{"data":null,"errors":[{"message":"forbidden"}]}"#;
+        let parsed: GqlResponse<WorkspacesData> = serde_json::from_str(body).expect("parse");
+        assert!(parsed.data.is_none());
+        assert_eq!(parsed.errors.len(), 1);
+        assert_eq!(parsed.errors[0].message, "forbidden");
+    }
+
+    #[test]
+    fn gql_response_parses_workspaces() {
+        let body = r#"{"data":{"workspaces":[{"id":"abc","public":false}]}}"#;
+        let parsed: GqlResponse<WorkspacesData> = serde_json::from_str(body).expect("parse");
+        let ws = parsed.data.expect("data");
+        assert_eq!(ws.workspaces.len(), 1);
+        assert_eq!(ws.workspaces[0].id, "abc");
+    }
+
+    #[test]
+    fn gql_response_parses_docs() {
+        let body = r#"{
+          "data": {
+            "workspace": {
+              "docs": {
+                "edges": [
+                  { "node": { "id": "d1", "title": "Notes" } },
+                  { "node": { "id": "d2", "title": null } }
+                ]
+              }
+            }
+          }
+        }"#;
+        let parsed: GqlResponse<DocsData> = serde_json::from_str(body).expect("parse");
+        let data = parsed.data.expect("data");
+        assert_eq!(data.workspace.docs.edges.len(), 2);
+        assert_eq!(data.workspace.docs.edges[0].node.id, "d1");
+        assert_eq!(
+            data.workspace.docs.edges[0].node.title.as_deref(),
+            Some("Notes")
+        );
+        assert!(data.workspace.docs.edges[1].node.title.is_none());
+    }
+}

--- a/crates/vox-export/src/affine/graphql.rs
+++ b/crates/vox-export/src/affine/graphql.rs
@@ -9,31 +9,13 @@ use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use super::auth::AuthHeaders;
-use crate::{
-    error::ExportError,
-    traits::{Folder, Workspace},
-};
+use crate::{error::ExportError, traits::Workspace};
 
 const WORKSPACES_QUERY: &str = r"
 query Workspaces {
   workspaces {
     id
     public
-  }
-}";
-
-const DOCS_QUERY: &str = r"
-query WorkspaceDocs($id: String!, $first: Int!, $offset: Int!) {
-  workspace(id: $id) {
-    id
-    docs(pagination: { first: $first, offset: $offset }) {
-      edges {
-        node {
-          id
-          title
-        }
-      }
-    }
   }
 }";
 
@@ -150,70 +132,6 @@ pub fn workspace_with_fallback_name(id: String) -> Workspace {
     }
 }
 
-#[derive(Deserialize)]
-struct DocsData {
-    workspace: DocsWorkspace,
-}
-
-#[derive(Deserialize)]
-struct DocsWorkspace {
-    docs: DocsConnection,
-}
-
-#[derive(Deserialize)]
-struct DocsConnection {
-    edges: Vec<DocsEdge>,
-}
-
-#[derive(Deserialize)]
-struct DocsEdge {
-    node: DocNode,
-}
-
-#[derive(Deserialize)]
-struct DocNode {
-    id: String,
-    #[serde(default)]
-    title: Option<String>,
-}
-
-#[derive(Serialize)]
-struct DocsVariables<'a> {
-    id: &'a str,
-    first: i32,
-    offset: i32,
-}
-
-/// Fetch the first page of docs in `workspace_id`. Returns up to 200 docs —
-/// enough for the Send-to picker; full pagination is not needed.
-///
-/// # Errors
-///
-/// Returns [`ExportError`] on transport or API failure.
-pub async fn list_docs(
-    http: &Client,
-    base_url: &str,
-    headers: &AuthHeaders,
-    workspace_id: &str,
-) -> Result<Vec<Folder>, ExportError> {
-    let vars = DocsVariables {
-        id: workspace_id,
-        first: 200,
-        offset: 0,
-    };
-    let data: DocsData = send(http, base_url, headers, DOCS_QUERY, Some(vars)).await?;
-    Ok(data
-        .workspace
-        .docs
-        .edges
-        .into_iter()
-        .map(|e| Folder {
-            id: e.node.id.clone(),
-            title: e.node.title.unwrap_or_else(|| "Untitled".to_owned()),
-        })
-        .collect())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -234,30 +152,5 @@ mod tests {
         let ws = parsed.data.expect("data");
         assert_eq!(ws.workspaces.len(), 1);
         assert_eq!(ws.workspaces[0].id, "abc");
-    }
-
-    #[test]
-    fn gql_response_parses_docs() {
-        let body = r#"{
-          "data": {
-            "workspace": {
-              "docs": {
-                "edges": [
-                  { "node": { "id": "d1", "title": "Notes" } },
-                  { "node": { "id": "d2", "title": null } }
-                ]
-              }
-            }
-          }
-        }"#;
-        let parsed: GqlResponse<DocsData> = serde_json::from_str(body).expect("parse");
-        let data = parsed.data.expect("data");
-        assert_eq!(data.workspace.docs.edges.len(), 2);
-        assert_eq!(data.workspace.docs.edges[0].node.id, "d1");
-        assert_eq!(
-            data.workspace.docs.edges[0].node.title.as_deref(),
-            Some("Notes")
-        );
-        assert!(data.workspace.docs.edges[1].node.title.is_none());
     }
 }

--- a/crates/vox-export/src/affine/mod.rs
+++ b/crates/vox-export/src/affine/mod.rs
@@ -27,11 +27,14 @@ pub mod graphql;
 pub mod socket;
 pub mod ydoc;
 
+use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use base64::Engine as _;
 use reqwest::Client;
+use tokio::sync::{Mutex as TokioMutex, MutexGuard};
 use tracing::{debug, info, instrument, warn};
 use vox_core::config::AffineExportConfig;
 
@@ -54,6 +57,16 @@ pub struct AffineTarget {
     http: Client,
     /// Authentication strategy.
     auth: auth::AuthState,
+    /// Lazily-connected Socket.IO client shared across all realtime
+    /// operations on this target.  Kept alive for the lifetime of the
+    /// `AffineTarget` so every call after the first pays no cold-start
+    /// cost (the first `space:join` on a fresh socket takes 20-45 s).
+    socket: Arc<TokioMutex<Option<socket::WorkspaceSocket>>>,
+    /// Folders (doc metadata) indexed by workspace id, populated as a
+    /// side-effect of [`Self::list_workspaces`] and consumed by
+    /// [`Self::list_folders`].  Both methods need the workspace root
+    /// doc; caching lets the folder picker render instantly.
+    folders_cache: Arc<TokioMutex<HashMap<String, Vec<Folder>>>>,
 }
 
 impl AffineTarget {
@@ -102,6 +115,8 @@ impl AffineTarget {
             base_url,
             http,
             auth,
+            socket: Arc::new(TokioMutex::new(None)),
+            folders_cache: Arc::new(TokioMutex::new(HashMap::new())),
         })
     }
 
@@ -115,7 +130,40 @@ impl AffineTarget {
             self.base_url.clone()
         }
     }
+
+    /// Acquire the shared Socket.IO client, opening a fresh connection on
+    /// first use.  Holding the returned guard serialises realtime ops,
+    /// which is required anyway — `AFFiNE` refuses concurrent emits from
+    /// the same user session.
+    ///
+    /// The `.as_ref().expect(…)` pattern at call-sites is safe: this
+    /// method installs `Some(…)` before returning.
+    async fn acquire_socket(
+        &self,
+    ) -> Result<MutexGuard<'_, Option<socket::WorkspaceSocket>>, ExportError> {
+        let mut guard = self.socket.lock().await;
+        if guard.is_none() {
+            let headers = self.auth.ensure_headers(&self.http, &self.base_url).await?;
+            let ws_url = self.ws_url();
+            let client = socket::WorkspaceSocket::connect(&ws_url, &headers).await?;
+            *guard = Some(client);
+        }
+        Ok(guard)
+    }
+
+    /// Forget the cached socket.  Next `acquire_socket` will reconnect.
+    /// Called on transport errors so a dead socket is not reused.
+    async fn reset_socket(&self) {
+        let mut guard = self.socket.lock().await;
+        if let Some(sock) = guard.take() {
+            sock.disconnect().await;
+        }
+    }
 }
+
+// No explicit Drop impl: when `AffineTarget` goes out of scope, the
+// `Arc<Mutex<Option<WorkspaceSocket>>>` drops, which drops the inner
+// `rust_socketio` client and closes the connection.
 
 #[async_trait]
 impl ExportTarget for AffineTarget {
@@ -132,16 +180,15 @@ impl ExportTarget for AffineTarget {
         let headers = self.auth.ensure_headers(&self.http, &self.base_url).await?;
         let ids = graphql::list_workspace_ids(&self.http, &self.base_url, &headers).await?;
 
-        // `AFFiNE` does not expose workspace names via GraphQL — they live
-        // in each workspace's root Yjs doc under `meta.name`.  We open a
-        // single Socket.IO connection and serially join each workspace,
-        // load its root doc, and leave.  Parallel fan-out was tried first
-        // but `AFFiNE` does not ack `space:join` when multiple fresh
-        // sockets race each other from the same user session.
-        let ws_url = self.ws_url();
+        // `AFFiNE` exposes neither workspace names nor doc titles via
+        // GraphQL — both live in each workspace's root Yjs doc.  Load
+        // that once per workspace on the shared socket: cache `meta.name`
+        // on the `Workspace` we return, and stash `meta.pages` in
+        // `folders_cache` so the subsequent `list_folders` call is
+        // instant.
         let mut workspaces = Vec::new();
-        let client = match socket::WorkspaceSocket::connect(&ws_url, &headers).await {
-            Ok(c) => c,
+        let guard = match self.acquire_socket().await {
+            Ok(g) => g,
             Err(e) => {
                 warn!(error = %e,
                     "failed to open socket for workspace-name lookup; using id placeholders");
@@ -152,69 +199,76 @@ impl ExportTarget for AffineTarget {
                 return Ok(workspaces);
             }
         };
+        let client = guard.as_ref().expect("acquire_socket returned Some");
 
-        // First pass.  The first `space:join` on a fresh socket takes
-        // 15–45s while the `AFFiNE` server cold-loads workspace state,
-        // which tends to eat whichever workspace goes first.  We track
-        // those so we can retry them once the socket is warm.
+        // First pass — the first `space:join` on a freshly-opened socket
+        // can take 20-45 s while the server cold-loads workspace state.
+        // Track anything that timed out or errored so we can retry once
+        // the socket is warm.
         let mut retry_ids = Vec::new();
         for id in &ids {
-            match resolve_workspace_name(&client, id).await {
+            match resolve_workspace_data(client, &self.folders_cache, id).await {
                 Ok(Some(name)) => workspaces.push(Workspace {
                     id: id.clone(),
                     name,
                 }),
                 Ok(None) => {
-                    // Doc loaded but carries no `meta.name` — no point
-                    // retrying; keep the placeholder.
                     workspaces.push(graphql::workspace_with_fallback_name(id.clone()));
                 }
                 Err(()) => retry_ids.push(id.clone()),
             }
         }
 
-        // Retry any that timed out / errored on the cold socket.  By now
-        // the socket is warm so these typically finish in milliseconds.
         for id in retry_ids {
-            let name = match resolve_workspace_name(&client, &id).await {
+            let name = match resolve_workspace_data(client, &self.folders_cache, &id).await {
                 Ok(Some(n)) => n,
                 Ok(None) | Err(()) => graphql::fallback_workspace_name(&id),
             };
             workspaces.push(Workspace { id, name });
         }
 
-        client.disconnect().await;
+        drop(guard);
         workspaces.sort_by(|a, b| a.name.cmp(&b.name));
         Ok(workspaces)
     }
 
     #[instrument(skip(self))]
     async fn list_folders(&self, workspace_id: &str) -> Result<Vec<Folder>, ExportError> {
-        // `AFFiNE`'s GraphQL `workspace(id).docs` returns `title: null` on
-        // self-hosted instances — the real title lives in each doc's Yjs
-        // body, and the workspace's root doc mirrors a `{id, title}` map
-        // of all its pages under `meta.pages`.  Load that once instead of
-        // fanning out per-doc.
-        let headers = self.auth.ensure_headers(&self.http, &self.base_url).await?;
-        let ws_url = self.ws_url();
-        let client = socket::WorkspaceSocket::connect(&ws_url, &headers).await?;
-        client.join(workspace_id).await?;
-        let bytes = client.load_doc(workspace_id, workspace_id).await?;
-        let _ = client.leave(workspace_id).await;
-        client.disconnect().await;
+        // Fast path: `list_workspaces` already populated the cache while
+        // fetching the workspace's name.
+        if let Some(folders) = self.folders_cache.lock().await.get(workspace_id) {
+            debug!(
+                workspace_id,
+                count = folders.len(),
+                "list_folders: cache hit"
+            );
+            return Ok(folders.clone());
+        }
 
-        let Some(bytes) = bytes else {
-            return Ok(Vec::new());
+        // Slow path (e.g. user opens the picker without `list_workspaces`
+        // having been called first): fetch the workspace root doc on the
+        // shared socket and extract `meta.pages`.
+        let guard = self.acquire_socket().await?;
+        let client = guard.as_ref().expect("acquire_socket returned Some");
+        let bytes = match join_load_leave(client, workspace_id).await {
+            Ok(b) => b,
+            Err(e) => {
+                drop(guard);
+                // Reset so a dead socket is reopened next call.
+                self.reset_socket().await;
+                return Err(e);
+            }
         };
-        let pages = ydoc::extract_workspace_pages(&bytes);
-        let mut folders: Vec<Folder> = pages
-            .into_iter()
-            .map(|p| Folder {
-                id: p.id,
-                title: p.title.unwrap_or_else(|| "Untitled".to_owned()),
-            })
-            .collect();
-        folders.sort_by(|a, b| a.title.cmp(&b.title));
+        drop(guard);
+
+        let folders = match bytes {
+            Some(b) => pages_to_folders(ydoc::extract_workspace_pages(&b)),
+            None => Vec::new(),
+        };
+        self.folders_cache
+            .lock()
+            .await
+            .insert(workspace_id.to_owned(), folders.clone());
         Ok(folders)
     }
 
@@ -225,15 +279,12 @@ impl ExportTarget for AffineTarget {
         parent_id: Option<&str>,
         title: &str,
     ) -> Result<Folder, ExportError> {
-        let headers = self.auth.ensure_headers(&self.http, &self.base_url).await?;
-        let ws_url = self.ws_url();
         let doc_id = uuid::Uuid::new_v4().to_string();
-
-        // Build an empty-bodied doc so it shows up as a usable parent.
         let doc_update = ydoc::build_doc_update(&doc_id, title, "")?;
         let workspace_meta_update = ydoc::build_workspace_meta_append(&doc_id, title);
 
-        let client = socket::WorkspaceSocket::connect(&ws_url, &headers).await?;
+        let guard = self.acquire_socket().await?;
+        let client = guard.as_ref().expect("acquire_socket returned Some");
         client.join(workspace_id).await?;
         client
             .push_doc_update(workspace_id, &doc_id, &encode(&doc_update))
@@ -241,35 +292,41 @@ impl ExportTarget for AffineTarget {
         client
             .push_doc_update(workspace_id, workspace_id, &encode(&workspace_meta_update))
             .await?;
-
-        // Nest under an existing parent if requested.
         if let Some(parent) = parent_id {
             let embed_update = ydoc::build_embed_linked_doc_block(parent, &doc_id)?;
             client
                 .push_doc_update(workspace_id, parent, &encode(&embed_update))
                 .await?;
         }
+        let _ = client.leave(workspace_id).await;
+        drop(guard);
 
-        client.disconnect().await;
+        let folder = Folder {
+            id: doc_id.clone(),
+            title: title.to_owned(),
+        };
+        // Keep the cache consistent with what the user just created.
+        self.folders_cache
+            .lock()
+            .await
+            .entry(workspace_id.to_owned())
+            .or_default()
+            .push(folder.clone());
 
         info!(doc_id, title, "created affine folder doc");
-        Ok(Folder {
-            id: doc_id,
-            title: title.to_owned(),
-        })
+        Ok(folder)
     }
 
     #[instrument(skip(self, request), fields(title = %request.title))]
     async fn export(&self, request: ExportRequest<'_>) -> Result<ExportResult, ExportError> {
-        let headers = self.auth.ensure_headers(&self.http, &self.base_url).await?;
-        let ws_url = self.ws_url();
         let doc_id = uuid::Uuid::new_v4().to_string();
 
         debug!(doc_id, "building yjs update for new affine doc");
         let doc_update = ydoc::build_doc_update(&doc_id, &request.title, request.content_markdown)?;
         let workspace_meta_update = ydoc::build_workspace_meta_append(&doc_id, &request.title);
 
-        let client = socket::WorkspaceSocket::connect(&ws_url, &headers).await?;
+        let guard = self.acquire_socket().await?;
+        let client = guard.as_ref().expect("acquire_socket returned Some");
         client.join(&request.workspace_id).await?;
         client
             .push_doc_update(&request.workspace_id, &doc_id, &encode(&doc_update))
@@ -282,14 +339,15 @@ impl ExportTarget for AffineTarget {
             )
             .await?;
 
-        if let Some(parent) = request.parent_id {
-            let embed_update = ydoc::build_embed_linked_doc_block(&parent, &doc_id)?;
+        if let Some(parent) = &request.parent_id {
+            let embed_update = ydoc::build_embed_linked_doc_block(parent, &doc_id)?;
             client
-                .push_doc_update(&request.workspace_id, &parent, &encode(&embed_update))
+                .push_doc_update(&request.workspace_id, parent, &encode(&embed_update))
                 .await?;
         }
 
-        client.disconnect().await;
+        let _ = client.leave(&request.workspace_id).await;
+        drop(guard);
 
         let remote_url = Some(format!(
             "{}/workspace/{}/{}",
@@ -308,86 +366,89 @@ fn encode(bytes: &[u8]) -> String {
     base64::engine::general_purpose::STANDARD.encode(bytes)
 }
 
-/// Run one attempt at resolving a workspace's name.
+/// Load the workspace root doc once and populate both the returned name
+/// and the per-target folders cache.
 ///
 /// Return values:
-/// - `Ok(Some(name))`: name resolved successfully.
-/// - `Ok(None)`: the workspace's root doc loaded but has no `meta.name`.
-///   Retrying won't help — caller should keep the placeholder.
-/// - `Err(())`: timeout or transport error; caller may retry.
-async fn resolve_workspace_name(
+/// - `Ok(Some(name))`: name resolved successfully; folders cached.
+/// - `Ok(None)`: the root doc loaded but has no `meta.name` (retry
+///   won't help; caller keeps the placeholder).
+/// - `Err(())`: timeout or transport error; caller may retry on the now-
+///   warm socket.
+async fn resolve_workspace_data(
     client: &socket::WorkspaceSocket,
+    folders_cache: &TokioMutex<HashMap<String, Vec<Folder>>>,
     workspace_id: &str,
 ) -> Result<Option<String>, ()> {
     match tokio::time::timeout(
         WORKSPACE_NAME_FETCH_TIMEOUT,
-        fetch_workspace_name_on(client, workspace_id),
+        join_load_leave(client, workspace_id),
     )
     .await
     {
-        Ok(Ok(name)) => Ok(name),
+        Ok(Ok(Some(bytes))) => {
+            let name = ydoc::extract_workspace_name(&bytes);
+            let folders = pages_to_folders(ydoc::extract_workspace_pages(&bytes));
+            folders_cache
+                .lock()
+                .await
+                .insert(workspace_id.to_owned(), folders);
+            Ok(name)
+        }
+        Ok(Ok(None)) => {
+            // Doc exists but is empty — no name, no pages.
+            folders_cache
+                .lock()
+                .await
+                .insert(workspace_id.to_owned(), Vec::new());
+            Ok(None)
+        }
         Ok(Err(e)) => {
             warn!(workspace = %workspace_id, error = %e,
-                "realtime workspace-name fetch failed; will retry");
+                "realtime workspace fetch failed; will retry");
             Err(())
         }
         Err(_) => {
-            warn!(workspace = %workspace_id, "workspace-name fetch timed out; will retry");
+            warn!(workspace = %workspace_id, "workspace fetch timed out; will retry");
             Err(())
         }
     }
 }
 
-/// Join the workspace on a pre-opened socket, load its root Yjs doc,
-/// extract `meta.name`, then leave again so the socket is clean for the
-/// next workspace.
-///
-/// Returns `Ok(None)` when the doc exists but has no name set.
-async fn fetch_workspace_name_on(
+/// Join a workspace on a pre-opened socket, load its root Yjs doc, and
+/// leave. Returns `Ok(None)` if the server reports no existing state.
+async fn join_load_leave(
     client: &socket::WorkspaceSocket,
     workspace_id: &str,
-) -> Result<Option<String>, ExportError> {
+) -> Result<Option<Vec<u8>>, ExportError> {
     let overall = std::time::Instant::now();
-
-    let step = std::time::Instant::now();
     client.join(workspace_id).await?;
-    debug!(
-        workspace_id,
-        elapsed_ms = u64::try_from(step.elapsed().as_millis()).unwrap_or(u64::MAX),
-        "workspace-name: joined"
-    );
-
-    let step = std::time::Instant::now();
     let bytes = client.load_doc(workspace_id, workspace_id).await?;
-    debug!(
-        workspace_id,
-        elapsed_ms = u64::try_from(step.elapsed().as_millis()).unwrap_or(u64::MAX),
-        bytes = bytes.as_ref().map_or(0, Vec::len),
-        "workspace-name: load-doc returned"
-    );
-
-    // Leave so the server's per-space adapter binding is released before
-    // the next `join`. Errors here are non-fatal.
+    // Leave is best-effort: we don't want a leave failure to mask an
+    // otherwise-successful load.
     if let Err(e) = client.leave(workspace_id).await {
-        debug!(workspace_id, error = %e, "workspace-name: leave failed (non-fatal)");
+        debug!(workspace_id, error = %e, "workspace root: leave failed (non-fatal)");
     }
-
-    let Some(bytes) = bytes else {
-        debug!(
-            workspace_id,
-            total_ms = u64::try_from(overall.elapsed().as_millis()).unwrap_or(u64::MAX),
-            "workspace-name: no bytes returned"
-        );
-        return Ok(None);
-    };
-    let name = ydoc::extract_workspace_name(&bytes);
     debug!(
         workspace_id,
         total_ms = u64::try_from(overall.elapsed().as_millis()).unwrap_or(u64::MAX),
-        resolved = name.is_some(),
-        "workspace-name: finished"
+        bytes = bytes.as_ref().map_or(0, Vec::len),
+        "workspace root: fetched"
     );
-    Ok(name)
+    Ok(bytes)
+}
+
+/// Convert extracted `meta.pages` entries to sorted [`Folder`]s.
+fn pages_to_folders(pages: Vec<ydoc::WorkspacePage>) -> Vec<Folder> {
+    let mut folders: Vec<Folder> = pages
+        .into_iter()
+        .map(|p| Folder {
+            id: p.id,
+            title: p.title.unwrap_or_else(|| "Untitled".to_owned()),
+        })
+        .collect();
+    folders.sort_by(|a, b| a.title.cmp(&b.title));
+    folders
 }
 
 #[cfg(test)]

--- a/crates/vox-export/src/affine/mod.rs
+++ b/crates/vox-export/src/affine/mod.rs
@@ -40,11 +40,11 @@ use crate::{
     traits::{ExportRequest, ExportResult, ExportTarget, Folder, Workspace},
 };
 
-/// Per-workspace timeout for the realtime name fetch.  Covers the full
-/// connect + join + load-doc round-trip.  Keeps a single slow workspace
-/// from blocking the rest of the list; callers fall back to the short-id
-/// placeholder on timeout.
-const WORKSPACE_NAME_FETCH_TIMEOUT: Duration = Duration::from_secs(20);
+/// Per-workspace timeout for the realtime name fetch.  Covers join +
+/// load-doc + leave.  Must be > the Socket.IO ack timeout because the
+/// first `space:join` on a fresh socket can take 15–25 s while the
+/// `AFFiNE` server cold-loads workspace state.
+const WORKSPACE_NAME_FETCH_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// `AFFiNE` export target.
 pub struct AffineTarget {

--- a/crates/vox-export/src/affine/mod.rs
+++ b/crates/vox-export/src/affine/mod.rs
@@ -1,0 +1,306 @@
+//! `AFFiNE` export target.
+//!
+//! Supports both `AFFiNE` Cloud (`app.affine.pro`, requires a personal access
+//! token — email/password sign-in is blocked by Cloudflare) and self-hosted
+//! instances (token or email/password).
+//!
+//! # Wire protocol
+//!
+//! `AFFiNE` does not expose a "create document with markdown" HTTP endpoint.
+//! Documents are Yjs CRDT blobs synchronised over Socket.IO. Exporting is a
+//! four-step dance:
+//!
+//! 1. Authenticate — either use the configured [`AffineExportConfig::api_token`]
+//!    directly, or exchange `email`/`password` for a session cookie via
+//!    `POST /api/auth/sign-in` (self-hosted only).
+//! 2. Query GraphQL at `/graphql` for workspace / doc metadata.
+//! 3. Connect to `wss://{host}/socket.io/`, join the workspace, and push a
+//!    freshly-constructed Yjs update containing the new document's blocks.
+//! 4. Amend the workspace's root Yjs doc (stored at the workspace id) to add
+//!    a `pages` entry so the doc appears in the workspace sidebar.
+//!
+//! Nesting under a parent doc is handled by appending an
+//! `affine:embed-linked-doc` block to that parent.
+
+pub mod auth;
+pub mod graphql;
+pub mod socket;
+pub mod ydoc;
+
+use async_trait::async_trait;
+use base64::Engine as _;
+use reqwest::Client;
+use tracing::{debug, info, instrument};
+use vox_core::config::AffineExportConfig;
+
+use crate::{
+    error::ExportError,
+    traits::{ExportRequest, ExportResult, ExportTarget, Folder, Workspace},
+};
+
+/// `AFFiNE` export target.
+pub struct AffineTarget {
+    /// Normalised base URL (no trailing slash).
+    base_url: String,
+    /// Shared HTTP client used for REST + GraphQL calls.
+    http: Client,
+    /// Authentication strategy.
+    auth: auth::AuthState,
+}
+
+impl AffineTarget {
+    /// Build an [`AffineTarget`] from its config section.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExportError::Config`] when required fields are missing or
+    /// when the HTTP client cannot be constructed.
+    pub fn from_config(cfg: &AffineExportConfig) -> Result<Self, ExportError> {
+        if cfg.base_url.trim().is_empty() {
+            return Err(ExportError::Config(
+                "affine.base_url must not be empty".to_owned(),
+            ));
+        }
+        let base_url = cfg.base_url.trim_end_matches('/').to_owned();
+
+        // Cloud blocks password sign-in; require a token.
+        let is_cloud = base_url.contains("affine.pro");
+        if is_cloud && cfg.api_token.trim().is_empty() {
+            return Err(ExportError::Config(
+                "affine.api_token is required for AFFiNE Cloud — \
+                 password sign-in is blocked; generate a token under \
+                 Settings → Integrations → MCP Server"
+                    .to_owned(),
+            ));
+        }
+        if cfg.api_token.trim().is_empty() && cfg.email.trim().is_empty() {
+            return Err(ExportError::Config(
+                "affine: set either api_token or email + password".to_owned(),
+            ));
+        }
+
+        let http = Client::builder()
+            .timeout(std::time::Duration::from_secs(60))
+            .build()
+            .map_err(|e| ExportError::Config(format!("failed to build HTTP client: {e}")))?;
+
+        let auth = if cfg.api_token.trim().is_empty() {
+            auth::AuthState::password(cfg.email.trim().to_owned(), cfg.password.clone())
+        } else {
+            auth::AuthState::token(cfg.api_token.trim().to_owned())
+        };
+
+        Ok(Self {
+            base_url,
+            http,
+            auth,
+        })
+    }
+
+    /// WebSocket URL derived from [`Self::base_url`].
+    fn ws_url(&self) -> String {
+        if let Some(rest) = self.base_url.strip_prefix("https://") {
+            format!("wss://{rest}")
+        } else if let Some(rest) = self.base_url.strip_prefix("http://") {
+            format!("ws://{rest}")
+        } else {
+            self.base_url.clone()
+        }
+    }
+}
+
+#[async_trait]
+impl ExportTarget for AffineTarget {
+    fn id(&self) -> &'static str {
+        "affine"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "AFFiNE"
+    }
+
+    #[instrument(skip(self), fields(base_url = %self.base_url))]
+    async fn list_workspaces(&self) -> Result<Vec<Workspace>, ExportError> {
+        let headers = self.auth.ensure_headers(&self.http, &self.base_url).await?;
+        graphql::list_workspaces(&self.http, &self.base_url, &headers).await
+    }
+
+    #[instrument(skip(self))]
+    async fn list_folders(&self, workspace_id: &str) -> Result<Vec<Folder>, ExportError> {
+        let headers = self.auth.ensure_headers(&self.http, &self.base_url).await?;
+        graphql::list_docs(&self.http, &self.base_url, &headers, workspace_id).await
+    }
+
+    #[instrument(skip(self, title))]
+    async fn create_folder(
+        &self,
+        workspace_id: &str,
+        parent_id: Option<&str>,
+        title: &str,
+    ) -> Result<Folder, ExportError> {
+        let headers = self.auth.ensure_headers(&self.http, &self.base_url).await?;
+        let ws_url = self.ws_url();
+        let doc_id = uuid::Uuid::new_v4().to_string();
+
+        // Build an empty-bodied doc so it shows up as a usable parent.
+        let doc_update = ydoc::build_doc_update(&doc_id, title, "")?;
+        let workspace_meta_update = ydoc::build_workspace_meta_append(&doc_id, title);
+
+        let client = socket::WorkspaceSocket::connect(&ws_url, &headers).await?;
+        client.join(workspace_id).await?;
+        client
+            .push_doc_update(workspace_id, &doc_id, &encode(&doc_update))
+            .await?;
+        client
+            .push_doc_update(workspace_id, workspace_id, &encode(&workspace_meta_update))
+            .await?;
+
+        // Nest under an existing parent if requested.
+        if let Some(parent) = parent_id {
+            let embed_update = ydoc::build_embed_linked_doc_block(parent, &doc_id)?;
+            client
+                .push_doc_update(workspace_id, parent, &encode(&embed_update))
+                .await?;
+        }
+
+        client.disconnect().await;
+
+        info!(doc_id, title, "created affine folder doc");
+        Ok(Folder {
+            id: doc_id,
+            title: title.to_owned(),
+        })
+    }
+
+    #[instrument(skip(self, request), fields(title = %request.title))]
+    async fn export(&self, request: ExportRequest<'_>) -> Result<ExportResult, ExportError> {
+        let headers = self.auth.ensure_headers(&self.http, &self.base_url).await?;
+        let ws_url = self.ws_url();
+        let doc_id = uuid::Uuid::new_v4().to_string();
+
+        debug!(doc_id, "building yjs update for new affine doc");
+        let doc_update = ydoc::build_doc_update(&doc_id, &request.title, request.content_markdown)?;
+        let workspace_meta_update = ydoc::build_workspace_meta_append(&doc_id, &request.title);
+
+        let client = socket::WorkspaceSocket::connect(&ws_url, &headers).await?;
+        client.join(&request.workspace_id).await?;
+        client
+            .push_doc_update(&request.workspace_id, &doc_id, &encode(&doc_update))
+            .await?;
+        client
+            .push_doc_update(
+                &request.workspace_id,
+                &request.workspace_id,
+                &encode(&workspace_meta_update),
+            )
+            .await?;
+
+        if let Some(parent) = request.parent_id {
+            let embed_update = ydoc::build_embed_linked_doc_block(&parent, &doc_id)?;
+            client
+                .push_doc_update(&request.workspace_id, &parent, &encode(&embed_update))
+                .await?;
+        }
+
+        client.disconnect().await;
+
+        let remote_url = Some(format!(
+            "{}/workspace/{}/{}",
+            self.base_url, request.workspace_id, doc_id
+        ));
+        info!(doc_id, url = ?remote_url, "exported session to affine");
+
+        Ok(ExportResult {
+            remote_id: doc_id,
+            remote_url,
+        })
+    }
+}
+
+fn encode(bytes: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cloud_cfg(token: &str) -> AffineExportConfig {
+        AffineExportConfig {
+            enabled: true,
+            base_url: "https://app.affine.pro".to_owned(),
+            api_token: token.to_owned(),
+            ..AffineExportConfig::default()
+        }
+    }
+
+    #[test]
+    fn from_config_rejects_empty_base_url() {
+        let cfg = AffineExportConfig {
+            enabled: true,
+            base_url: String::new(),
+            api_token: "t".to_owned(),
+            ..AffineExportConfig::default()
+        };
+        assert!(matches!(
+            AffineTarget::from_config(&cfg),
+            Err(ExportError::Config(_))
+        ));
+    }
+
+    #[test]
+    fn from_config_rejects_cloud_without_token() {
+        let cfg = AffineExportConfig {
+            enabled: true,
+            base_url: "https://app.affine.pro".to_owned(),
+            email: "a@b".to_owned(),
+            password: "p".to_owned(),
+            ..AffineExportConfig::default()
+        };
+        match AffineTarget::from_config(&cfg) {
+            Err(ExportError::Config(msg)) => {
+                assert!(msg.contains("api_token"), "unexpected message: {msg}");
+            }
+            Err(e) => panic!("expected Config error, got {e:?}"),
+            Ok(_) => panic!("expected error, got Ok"),
+        }
+    }
+
+    #[test]
+    fn from_config_rejects_missing_auth() {
+        let cfg = AffineExportConfig {
+            enabled: true,
+            base_url: "https://affine.example.com".to_owned(),
+            ..AffineExportConfig::default()
+        };
+        assert!(matches!(
+            AffineTarget::from_config(&cfg),
+            Err(ExportError::Config(_))
+        ));
+    }
+
+    #[test]
+    fn from_config_accepts_cloud_token() {
+        let t = AffineTarget::from_config(&cloud_cfg("ut_secret")).expect("build");
+        assert_eq!(t.base_url, "https://app.affine.pro");
+    }
+
+    #[test]
+    fn from_config_normalises_trailing_slash() {
+        let cfg = AffineExportConfig {
+            enabled: true,
+            base_url: "https://affine.example.com/".to_owned(),
+            email: "a".to_owned(),
+            password: "p".to_owned(),
+            ..AffineExportConfig::default()
+        };
+        let t = AffineTarget::from_config(&cfg).expect("build");
+        assert_eq!(t.base_url, "https://affine.example.com");
+    }
+
+    #[test]
+    fn ws_url_swaps_scheme() {
+        let t = AffineTarget::from_config(&cloud_cfg("t")).expect("build");
+        assert_eq!(t.ws_url(), "wss://app.affine.pro");
+    }
+}

--- a/crates/vox-export/src/affine/mod.rs
+++ b/crates/vox-export/src/affine/mod.rs
@@ -42,10 +42,11 @@ use crate::{
     traits::{ExportRequest, ExportResult, ExportTarget, Folder, Workspace},
 };
 
-/// Per-workspace timeout for the realtime name fetch.  Keeps a single slow
-/// workspace from blocking the rest of the list; callers fall back to the
-/// short-id placeholder on timeout.
-const WORKSPACE_NAME_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+/// Per-workspace timeout for the realtime name fetch.  Covers the full
+/// connect + join + load-doc round-trip.  Keeps a single slow workspace
+/// from blocking the rest of the list; callers fall back to the short-id
+/// placeholder on timeout.
+const WORKSPACE_NAME_FETCH_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// `AFFiNE` export target.
 pub struct AffineTarget {
@@ -282,14 +283,51 @@ async fn fetch_workspace_name(
     headers: &AuthHeaders,
     workspace_id: &str,
 ) -> Result<Option<String>, ExportError> {
+    let overall = std::time::Instant::now();
+
+    let step = std::time::Instant::now();
     let client = socket::WorkspaceSocket::connect(ws_url, headers).await?;
+    debug!(
+        workspace_id,
+        elapsed_ms = u64::try_from(step.elapsed().as_millis()).unwrap_or(u64::MAX),
+        "workspace-name: connected"
+    );
+
+    let step = std::time::Instant::now();
     client.join(workspace_id).await?;
+    debug!(
+        workspace_id,
+        elapsed_ms = u64::try_from(step.elapsed().as_millis()).unwrap_or(u64::MAX),
+        "workspace-name: joined"
+    );
+
+    let step = std::time::Instant::now();
     let bytes = client.load_doc(workspace_id, workspace_id).await?;
+    debug!(
+        workspace_id,
+        elapsed_ms = u64::try_from(step.elapsed().as_millis()).unwrap_or(u64::MAX),
+        bytes = bytes.as_ref().map_or(0, Vec::len),
+        "workspace-name: load-doc returned"
+    );
+
     client.disconnect().await;
+
     let Some(bytes) = bytes else {
+        debug!(
+            workspace_id,
+            total_ms = u64::try_from(overall.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "workspace-name: no bytes returned"
+        );
         return Ok(None);
     };
-    Ok(ydoc::extract_workspace_name(&bytes))
+    let name = ydoc::extract_workspace_name(&bytes);
+    debug!(
+        workspace_id,
+        total_ms = u64::try_from(overall.elapsed().as_millis()).unwrap_or(u64::MAX),
+        resolved = name.is_some(),
+        "workspace-name: finished"
+    );
+    Ok(name)
 }
 
 #[cfg(test)]

--- a/crates/vox-export/src/affine/mod.rs
+++ b/crates/vox-export/src/affine/mod.rs
@@ -190,8 +190,32 @@ impl ExportTarget for AffineTarget {
 
     #[instrument(skip(self))]
     async fn list_folders(&self, workspace_id: &str) -> Result<Vec<Folder>, ExportError> {
+        // `AFFiNE`'s GraphQL `workspace(id).docs` returns `title: null` on
+        // self-hosted instances — the real title lives in each doc's Yjs
+        // body, and the workspace's root doc mirrors a `{id, title}` map
+        // of all its pages under `meta.pages`.  Load that once instead of
+        // fanning out per-doc.
         let headers = self.auth.ensure_headers(&self.http, &self.base_url).await?;
-        graphql::list_docs(&self.http, &self.base_url, &headers, workspace_id).await
+        let ws_url = self.ws_url();
+        let client = socket::WorkspaceSocket::connect(&ws_url, &headers).await?;
+        client.join(workspace_id).await?;
+        let bytes = client.load_doc(workspace_id, workspace_id).await?;
+        let _ = client.leave(workspace_id).await;
+        client.disconnect().await;
+
+        let Some(bytes) = bytes else {
+            return Ok(Vec::new());
+        };
+        let pages = ydoc::extract_workspace_pages(&bytes);
+        let mut folders: Vec<Folder> = pages
+            .into_iter()
+            .map(|p| Folder {
+                id: p.id,
+                title: p.title.unwrap_or_else(|| "Untitled".to_owned()),
+            })
+            .collect();
+        folders.sort_by(|a, b| a.title.cmp(&b.title));
+        Ok(folders)
     }
 
     #[instrument(skip(self, title))]

--- a/crates/vox-export/src/affine/mod.rs
+++ b/crates/vox-export/src/affine/mod.rs
@@ -32,11 +32,9 @@ use std::time::Duration;
 use async_trait::async_trait;
 use base64::Engine as _;
 use reqwest::Client;
-use tokio::task::JoinSet;
 use tracing::{debug, info, instrument, warn};
 use vox_core::config::AffineExportConfig;
 
-use self::auth::AuthHeaders;
 use crate::{
     error::ExportError,
     traits::{ExportRequest, ExportResult, ExportTarget, Folder, Workspace},
@@ -134,47 +132,50 @@ impl ExportTarget for AffineTarget {
         let headers = self.auth.ensure_headers(&self.http, &self.base_url).await?;
         let ids = graphql::list_workspace_ids(&self.http, &self.base_url, &headers).await?;
 
-        // `AFFiNE` does not expose workspace names via GraphQL — they live in
-        // each workspace's root Yjs doc under `meta.name`. Fan out the
-        // realtime fetches so the picker doesn't stall on a slow workspace;
-        // individual failures / timeouts fall back to the short-id name.
+        // `AFFiNE` does not expose workspace names via GraphQL — they live
+        // in each workspace's root Yjs doc under `meta.name`.  We open a
+        // single Socket.IO connection and serially join each workspace,
+        // load its root doc, and leave.  Parallel fan-out was tried first
+        // but `AFFiNE` does not ack `space:join` when multiple fresh
+        // sockets race each other from the same user session.
         let ws_url = self.ws_url();
-        let mut set: JoinSet<Workspace> = JoinSet::new();
-        for id in ids {
-            let ws_url = ws_url.clone();
-            let headers = headers.clone();
-            set.spawn(async move {
-                let name = tokio::time::timeout(
-                    WORKSPACE_NAME_FETCH_TIMEOUT,
-                    fetch_workspace_name(&ws_url, &headers, &id),
-                )
-                .await;
-
-                let resolved = match name {
-                    Ok(Ok(Some(n))) => n,
-                    Ok(Ok(None)) => graphql::fallback_workspace_name(&id),
-                    Ok(Err(e)) => {
-                        warn!(workspace = %id, error = %e,
-                            "realtime workspace-name fetch failed; using id");
-                        graphql::fallback_workspace_name(&id)
-                    }
-                    Err(_) => {
-                        warn!(workspace = %id, "workspace-name fetch timed out; using id");
-                        graphql::fallback_workspace_name(&id)
-                    }
-                };
-                Workspace { id, name: resolved }
-            });
-        }
-
         let mut workspaces = Vec::new();
-        while let Some(joined) = set.join_next().await {
-            match joined {
-                Ok(ws) => workspaces.push(ws),
-                Err(e) => warn!(error = %e, "workspace-name task panicked"),
+        let client = match socket::WorkspaceSocket::connect(&ws_url, &headers).await {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(error = %e,
+                    "failed to open socket for workspace-name lookup; using id placeholders");
+                for id in ids {
+                    workspaces.push(graphql::workspace_with_fallback_name(id));
+                }
+                workspaces.sort_by(|a, b| a.name.cmp(&b.name));
+                return Ok(workspaces);
             }
+        };
+
+        for id in ids {
+            let resolved = match tokio::time::timeout(
+                WORKSPACE_NAME_FETCH_TIMEOUT,
+                fetch_workspace_name_on(&client, &id),
+            )
+            .await
+            {
+                Ok(Ok(Some(n))) => n,
+                Ok(Ok(None)) => graphql::fallback_workspace_name(&id),
+                Ok(Err(e)) => {
+                    warn!(workspace = %id, error = %e,
+                        "realtime workspace-name fetch failed; using id");
+                    graphql::fallback_workspace_name(&id)
+                }
+                Err(_) => {
+                    warn!(workspace = %id, "workspace-name fetch timed out; using id");
+                    graphql::fallback_workspace_name(&id)
+                }
+            };
+            workspaces.push(Workspace { id, name: resolved });
         }
-        // Sort by display name so the picker order is stable across calls.
+
+        client.disconnect().await;
         workspaces.sort_by(|a, b| a.name.cmp(&b.name));
         Ok(workspaces)
     }
@@ -275,23 +276,16 @@ fn encode(bytes: &[u8]) -> String {
     base64::engine::general_purpose::STANDARD.encode(bytes)
 }
 
-/// Open a short-lived Socket.IO connection, load the workspace's root Yjs
-/// doc, and extract `meta.name`.  Returns `Ok(None)` when the doc exists
-/// but has no name set (e.g. fresh workspace).
-async fn fetch_workspace_name(
-    ws_url: &str,
-    headers: &AuthHeaders,
+/// Join the workspace on a pre-opened socket, load its root Yjs doc,
+/// extract `meta.name`, then leave again so the socket is clean for the
+/// next workspace.
+///
+/// Returns `Ok(None)` when the doc exists but has no name set.
+async fn fetch_workspace_name_on(
+    client: &socket::WorkspaceSocket,
     workspace_id: &str,
 ) -> Result<Option<String>, ExportError> {
     let overall = std::time::Instant::now();
-
-    let step = std::time::Instant::now();
-    let client = socket::WorkspaceSocket::connect(ws_url, headers).await?;
-    debug!(
-        workspace_id,
-        elapsed_ms = u64::try_from(step.elapsed().as_millis()).unwrap_or(u64::MAX),
-        "workspace-name: connected"
-    );
 
     let step = std::time::Instant::now();
     client.join(workspace_id).await?;
@@ -310,7 +304,11 @@ async fn fetch_workspace_name(
         "workspace-name: load-doc returned"
     );
 
-    client.disconnect().await;
+    // Leave so the server's per-space adapter binding is released before
+    // the next `join`. Errors here are non-fatal.
+    if let Err(e) = client.leave(workspace_id).await {
+        debug!(workspace_id, error = %e, "workspace-name: leave failed (non-fatal)");
+    }
 
     let Some(bytes) = bytes else {
         debug!(

--- a/crates/vox-export/src/affine/mod.rs
+++ b/crates/vox-export/src/affine/mod.rs
@@ -153,26 +153,34 @@ impl ExportTarget for AffineTarget {
             }
         };
 
-        for id in ids {
-            let resolved = match tokio::time::timeout(
-                WORKSPACE_NAME_FETCH_TIMEOUT,
-                fetch_workspace_name_on(&client, &id),
-            )
-            .await
-            {
-                Ok(Ok(Some(n))) => n,
-                Ok(Ok(None)) => graphql::fallback_workspace_name(&id),
-                Ok(Err(e)) => {
-                    warn!(workspace = %id, error = %e,
-                        "realtime workspace-name fetch failed; using id");
-                    graphql::fallback_workspace_name(&id)
+        // First pass.  The first `space:join` on a fresh socket takes
+        // 15–45s while the `AFFiNE` server cold-loads workspace state,
+        // which tends to eat whichever workspace goes first.  We track
+        // those so we can retry them once the socket is warm.
+        let mut retry_ids = Vec::new();
+        for id in &ids {
+            match resolve_workspace_name(&client, id).await {
+                Ok(Some(name)) => workspaces.push(Workspace {
+                    id: id.clone(),
+                    name,
+                }),
+                Ok(None) => {
+                    // Doc loaded but carries no `meta.name` — no point
+                    // retrying; keep the placeholder.
+                    workspaces.push(graphql::workspace_with_fallback_name(id.clone()));
                 }
-                Err(_) => {
-                    warn!(workspace = %id, "workspace-name fetch timed out; using id");
-                    graphql::fallback_workspace_name(&id)
-                }
+                Err(()) => retry_ids.push(id.clone()),
+            }
+        }
+
+        // Retry any that timed out / errored on the cold socket.  By now
+        // the socket is warm so these typically finish in milliseconds.
+        for id in retry_ids {
+            let name = match resolve_workspace_name(&client, &id).await {
+                Ok(Some(n)) => n,
+                Ok(None) | Err(()) => graphql::fallback_workspace_name(&id),
             };
-            workspaces.push(Workspace { id, name: resolved });
+            workspaces.push(Workspace { id, name });
         }
 
         client.disconnect().await;
@@ -274,6 +282,36 @@ impl ExportTarget for AffineTarget {
 
 fn encode(bytes: &[u8]) -> String {
     base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+/// Run one attempt at resolving a workspace's name.
+///
+/// Return values:
+/// - `Ok(Some(name))`: name resolved successfully.
+/// - `Ok(None)`: the workspace's root doc loaded but has no `meta.name`.
+///   Retrying won't help — caller should keep the placeholder.
+/// - `Err(())`: timeout or transport error; caller may retry.
+async fn resolve_workspace_name(
+    client: &socket::WorkspaceSocket,
+    workspace_id: &str,
+) -> Result<Option<String>, ()> {
+    match tokio::time::timeout(
+        WORKSPACE_NAME_FETCH_TIMEOUT,
+        fetch_workspace_name_on(client, workspace_id),
+    )
+    .await
+    {
+        Ok(Ok(name)) => Ok(name),
+        Ok(Err(e)) => {
+            warn!(workspace = %workspace_id, error = %e,
+                "realtime workspace-name fetch failed; will retry");
+            Err(())
+        }
+        Err(_) => {
+            warn!(workspace = %workspace_id, "workspace-name fetch timed out; will retry");
+            Err(())
+        }
+    }
 }
 
 /// Join the workspace on a pre-opened socket, load its root Yjs doc,

--- a/crates/vox-export/src/affine/mod.rs
+++ b/crates/vox-export/src/affine/mod.rs
@@ -27,16 +27,25 @@ pub mod graphql;
 pub mod socket;
 pub mod ydoc;
 
+use std::time::Duration;
+
 use async_trait::async_trait;
 use base64::Engine as _;
 use reqwest::Client;
-use tracing::{debug, info, instrument};
+use tokio::task::JoinSet;
+use tracing::{debug, info, instrument, warn};
 use vox_core::config::AffineExportConfig;
 
+use self::auth::AuthHeaders;
 use crate::{
     error::ExportError,
     traits::{ExportRequest, ExportResult, ExportTarget, Folder, Workspace},
 };
+
+/// Per-workspace timeout for the realtime name fetch.  Keeps a single slow
+/// workspace from blocking the rest of the list; callers fall back to the
+/// short-id placeholder on timeout.
+const WORKSPACE_NAME_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// `AFFiNE` export target.
 pub struct AffineTarget {
@@ -122,7 +131,51 @@ impl ExportTarget for AffineTarget {
     #[instrument(skip(self), fields(base_url = %self.base_url))]
     async fn list_workspaces(&self) -> Result<Vec<Workspace>, ExportError> {
         let headers = self.auth.ensure_headers(&self.http, &self.base_url).await?;
-        graphql::list_workspaces(&self.http, &self.base_url, &headers).await
+        let ids = graphql::list_workspace_ids(&self.http, &self.base_url, &headers).await?;
+
+        // `AFFiNE` does not expose workspace names via GraphQL — they live in
+        // each workspace's root Yjs doc under `meta.name`. Fan out the
+        // realtime fetches so the picker doesn't stall on a slow workspace;
+        // individual failures / timeouts fall back to the short-id name.
+        let ws_url = self.ws_url();
+        let mut set: JoinSet<Workspace> = JoinSet::new();
+        for id in ids {
+            let ws_url = ws_url.clone();
+            let headers = headers.clone();
+            set.spawn(async move {
+                let name = tokio::time::timeout(
+                    WORKSPACE_NAME_FETCH_TIMEOUT,
+                    fetch_workspace_name(&ws_url, &headers, &id),
+                )
+                .await;
+
+                let resolved = match name {
+                    Ok(Ok(Some(n))) => n,
+                    Ok(Ok(None)) => graphql::fallback_workspace_name(&id),
+                    Ok(Err(e)) => {
+                        warn!(workspace = %id, error = %e,
+                            "realtime workspace-name fetch failed; using id");
+                        graphql::fallback_workspace_name(&id)
+                    }
+                    Err(_) => {
+                        warn!(workspace = %id, "workspace-name fetch timed out; using id");
+                        graphql::fallback_workspace_name(&id)
+                    }
+                };
+                Workspace { id, name: resolved }
+            });
+        }
+
+        let mut workspaces = Vec::new();
+        while let Some(joined) = set.join_next().await {
+            match joined {
+                Ok(ws) => workspaces.push(ws),
+                Err(e) => warn!(error = %e, "workspace-name task panicked"),
+            }
+        }
+        // Sort by display name so the picker order is stable across calls.
+        workspaces.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(workspaces)
     }
 
     #[instrument(skip(self))]
@@ -219,6 +272,24 @@ impl ExportTarget for AffineTarget {
 
 fn encode(bytes: &[u8]) -> String {
     base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+/// Open a short-lived Socket.IO connection, load the workspace's root Yjs
+/// doc, and extract `meta.name`.  Returns `Ok(None)` when the doc exists
+/// but has no name set (e.g. fresh workspace).
+async fn fetch_workspace_name(
+    ws_url: &str,
+    headers: &AuthHeaders,
+    workspace_id: &str,
+) -> Result<Option<String>, ExportError> {
+    let client = socket::WorkspaceSocket::connect(ws_url, headers).await?;
+    client.join(workspace_id).await?;
+    let bytes = client.load_doc(workspace_id, workspace_id).await?;
+    client.disconnect().await;
+    let Some(bytes) = bytes else {
+        return Ok(None);
+    };
+    Ok(ydoc::extract_workspace_name(&bytes))
 }
 
 #[cfg(test)]

--- a/crates/vox-export/src/affine/socket.rs
+++ b/crates/vox-export/src/affine/socket.rs
@@ -67,6 +67,22 @@ impl WorkspaceSocket {
         check_ack_error("space:join", &ack)
     }
 
+    /// Emit `space:leave` so the server releases its adapter binding for
+    /// this space. Call between `join`s when reusing one socket across
+    /// multiple workspaces.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExportError::Transport`] if the server acks with an error.
+    pub async fn leave(&self, workspace_id: &str) -> Result<(), ExportError> {
+        let payload = json!({
+            "spaceType": "workspace",
+            "spaceId": workspace_id,
+        });
+        let ack = self.emit_with_ack("space:leave", payload).await?;
+        check_ack_error("space:leave", &ack)
+    }
+
     /// Emit `space:push-doc-update` with a base64-encoded Yjs update.
     ///
     /// # Errors

--- a/crates/vox-export/src/affine/socket.rs
+++ b/crates/vox-export/src/affine/socket.rs
@@ -1,0 +1,144 @@
+//! Socket.IO client wrapper for `AFFiNE`'s realtime doc-sync endpoint.
+//!
+//! Connects to `wss://<host>/socket.io/`, then emits Socket.IO events
+//! (`space:join`, `space:push-doc-update`) to push Yjs CRDT updates.
+
+use std::time::Duration;
+
+use rust_socketio::{
+    Payload,
+    asynchronous::{Client as SioClient, ClientBuilder},
+};
+use serde_json::{Value, json};
+use tracing::debug;
+
+use super::auth::AuthHeaders;
+use crate::error::ExportError;
+
+/// Client-version string echoed to `space:join`. Must be recent enough that
+/// the `AFFiNE` server does not reject us as an outdated client.
+const CLIENT_VERSION: &str = "0.26.0";
+
+/// Timeout for each Socket.IO ack round-trip.
+const ACK_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Connected Socket.IO client scoped to one `AFFiNE` workspace session.
+pub struct WorkspaceSocket {
+    client: SioClient,
+}
+
+impl WorkspaceSocket {
+    /// Open a Socket.IO connection to `ws_url`, injecting auth headers.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExportError::Transport`] when the socket cannot be opened.
+    pub async fn connect(ws_url: &str, auth: &AuthHeaders) -> Result<Self, ExportError> {
+        let mut builder =
+            ClientBuilder::new(ws_url).transport_type(rust_socketio::TransportType::Websocket);
+        if let Some(b) = &auth.bearer {
+            builder = builder.opening_header("Authorization", format!("Bearer {b}"));
+        }
+        if let Some(c) = &auth.cookie {
+            builder = builder.opening_header("Cookie", c.clone());
+        }
+
+        let client = builder
+            .connect()
+            .await
+            .map_err(|e| ExportError::Transport(format!("socket connect failed: {e}")))?;
+        Ok(Self { client })
+    }
+
+    /// Emit `space:join` for the given workspace and await the ack.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExportError::Transport`] if the server acks with an error
+    /// or the round-trip times out.
+    pub async fn join(&self, workspace_id: &str) -> Result<(), ExportError> {
+        let payload = json!({
+            "spaceType": "workspace",
+            "spaceId": workspace_id,
+            "clientVersion": CLIENT_VERSION,
+        });
+        self.emit_with_ack("space:join", payload).await?;
+        Ok(())
+    }
+
+    /// Emit `space:push-doc-update` with a base64-encoded Yjs update.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExportError::Transport`] if the server acks with an error.
+    pub async fn push_doc_update(
+        &self,
+        workspace_id: &str,
+        doc_id: &str,
+        update_base64: &str,
+    ) -> Result<(), ExportError> {
+        let payload = json!({
+            "spaceType": "workspace",
+            "spaceId": workspace_id,
+            "docId": doc_id,
+            "update": update_base64,
+        });
+        self.emit_with_ack("space:push-doc-update", payload).await?;
+        Ok(())
+    }
+
+    /// Gracefully close the Socket.IO connection. Errors are logged and
+    /// swallowed — a failed disconnect should not mask a successful push.
+    pub async fn disconnect(self) {
+        if let Err(e) = self.client.disconnect().await {
+            debug!(error = %e, "socket disconnect failed");
+        }
+    }
+
+    /// Emit an event and await its server ack, returning the raw JSON of the
+    /// ack payload.
+    async fn emit_with_ack(
+        &self,
+        event: &'static str,
+        payload: Value,
+    ) -> Result<Value, ExportError> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let tx = std::sync::Arc::new(std::sync::Mutex::new(Some(tx)));
+
+        let callback_tx = tx.clone();
+        self.client
+            .emit_with_ack(
+                event,
+                Payload::Text(vec![payload]),
+                ACK_TIMEOUT,
+                move |ack, _| {
+                    let callback_tx = callback_tx.clone();
+                    Box::pin(async move {
+                        let value = match ack {
+                            Payload::Text(v) => v.into_iter().next().unwrap_or(Value::Null),
+                            _ => Value::Null,
+                        };
+                        if let Some(sender) = callback_tx.lock().ok().and_then(|mut g| g.take()) {
+                            let _ = sender.send(value);
+                        }
+                    })
+                },
+            )
+            .await
+            .map_err(|e| ExportError::Transport(format!("{event} emit failed: {e}")))?;
+
+        let ack = tokio::time::timeout(ACK_TIMEOUT + Duration::from_secs(1), rx)
+            .await
+            .map_err(|_| ExportError::Transport(format!("{event} ack timeout")))?
+            .map_err(|_| ExportError::Transport(format!("{event} ack channel dropped")))?;
+
+        if let Some(err_obj) = ack.get("error") {
+            let msg = err_obj
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("unknown error");
+            return Err(ExportError::Transport(format!("{event}: {msg}")));
+        }
+        Ok(ack)
+    }
+}

--- a/crates/vox-export/src/affine/socket.rs
+++ b/crates/vox-export/src/affine/socket.rs
@@ -170,7 +170,11 @@ impl WorkspaceSocket {
 
     /// Gracefully close the Socket.IO connection. Errors are logged and
     /// swallowed — a failed disconnect should not mask a successful push.
-    pub async fn disconnect(self) {
+    ///
+    /// Takes `&self` so a pooled socket can be explicitly closed without
+    /// being moved out of its container; dropping the `WorkspaceSocket`
+    /// also closes the underlying `rust_socketio` client.
+    pub async fn disconnect(&self) {
         if let Err(e) = self.client.disconnect().await {
             debug!(error = %e, "socket disconnect failed");
         }

--- a/crates/vox-export/src/affine/socket.rs
+++ b/crates/vox-export/src/affine/socket.rs
@@ -5,6 +5,7 @@
 
 use std::time::Duration;
 
+use base64::Engine as _;
 use rust_socketio::{
     Payload,
     asynchronous::{Client as SioClient, ClientBuilder},
@@ -62,8 +63,8 @@ impl WorkspaceSocket {
             "spaceId": workspace_id,
             "clientVersion": CLIENT_VERSION,
         });
-        self.emit_with_ack("space:join", payload).await?;
-        Ok(())
+        let ack = self.emit_with_ack("space:join", payload).await?;
+        check_ack_error("space:join", &ack)
     }
 
     /// Emit `space:push-doc-update` with a base64-encoded Yjs update.
@@ -83,8 +84,57 @@ impl WorkspaceSocket {
             "docId": doc_id,
             "update": update_base64,
         });
-        self.emit_with_ack("space:push-doc-update", payload).await?;
-        Ok(())
+        let ack = self.emit_with_ack("space:push-doc-update", payload).await?;
+        check_ack_error("space:push-doc-update", &ack)
+    }
+
+    /// Emit `space:load-doc` and decode the server's Yjs update payload.
+    ///
+    /// Returns `Ok(None)` when the doc does not yet exist (server replies
+    /// with `error.name = "DOC_NOT_FOUND"`) — that is a valid response for a
+    /// fresh workspace whose root doc has never been persisted.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExportError::Transport`] on any other server error or
+    /// [`ExportError::ParseError`] if the base64 payload is malformed.
+    pub async fn load_doc(
+        &self,
+        workspace_id: &str,
+        doc_id: &str,
+    ) -> Result<Option<Vec<u8>>, ExportError> {
+        let payload = json!({
+            "spaceType": "workspace",
+            "spaceId": workspace_id,
+            "docId": doc_id,
+        });
+        let ack = self.emit_with_ack("space:load-doc", payload).await?;
+
+        if let Some(err_obj) = ack.get("error") {
+            let name = err_obj.get("name").and_then(|n| n.as_str()).unwrap_or("");
+            if name == "DOC_NOT_FOUND" {
+                return Ok(None);
+            }
+            let msg = err_obj
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("unknown error");
+            return Err(ExportError::Transport(format!("space:load-doc: {msg}")));
+        }
+
+        let Some(b64) = ack
+            .get("data")
+            .and_then(|d| d.get("missing"))
+            .and_then(|v| v.as_str())
+        else {
+            return Ok(None);
+        };
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(b64)
+            .map_err(|e| ExportError::ParseError {
+                reason: format!("space:load-doc base64 decode: {e}"),
+            })?;
+        Ok(Some(bytes))
     }
 
     /// Gracefully close the Socket.IO connection. Errors are logged and
@@ -131,14 +181,19 @@ impl WorkspaceSocket {
             .await
             .map_err(|_| ExportError::Transport(format!("{event} ack timeout")))?
             .map_err(|_| ExportError::Transport(format!("{event} ack channel dropped")))?;
-
-        if let Some(err_obj) = ack.get("error") {
-            let msg = err_obj
-                .get("message")
-                .and_then(|m| m.as_str())
-                .unwrap_or("unknown error");
-            return Err(ExportError::Transport(format!("{event}: {msg}")));
-        }
         Ok(ack)
     }
+}
+
+/// Treat the `error` field (if present) of an ack as a transport failure.
+/// Used by events that have no graceful "not found" path.
+fn check_ack_error(event: &'static str, ack: &Value) -> Result<(), ExportError> {
+    if let Some(err_obj) = ack.get("error") {
+        let msg = err_obj
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or("unknown error");
+        return Err(ExportError::Transport(format!("{event}: {msg}")));
+    }
+    Ok(())
 }

--- a/crates/vox-export/src/affine/socket.rs
+++ b/crates/vox-export/src/affine/socket.rs
@@ -181,7 +181,35 @@ impl WorkspaceSocket {
             .await
             .map_err(|_| ExportError::Transport(format!("{event} ack timeout")))?
             .map_err(|_| ExportError::Transport(format!("{event} ack channel dropped")))?;
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            let shape = ack_debug_shape(&ack);
+            debug!(event, ack_shape = %shape, "ack received");
+        }
         Ok(ack)
+    }
+}
+
+/// Summarise the ack JSON for diagnostic logs without dumping huge base64
+/// blobs into the terminal.
+fn ack_debug_shape(ack: &Value) -> String {
+    match ack {
+        Value::Null => "null".to_owned(),
+        Value::Object(map) => {
+            let keys: Vec<String> = map
+                .iter()
+                .map(|(k, v)| match v {
+                    Value::Object(inner) => {
+                        let inner_keys: Vec<&str> = inner.keys().map(String::as_str).collect();
+                        format!("{k}: {{ {} }}", inner_keys.join(", "))
+                    }
+                    Value::String(s) if s.len() > 40 => format!("{k}: <string len={}>", s.len()),
+                    other => format!("{k}: {other}"),
+                })
+                .collect();
+            format!("{{ {} }}", keys.join(", "))
+        }
+        Value::Array(a) => format!("array len={}", a.len()),
+        other => other.to_string(),
     }
 }
 

--- a/crates/vox-export/src/affine/socket.rs
+++ b/crates/vox-export/src/affine/socket.rs
@@ -21,7 +21,11 @@ use crate::error::ExportError;
 const CLIENT_VERSION: &str = "0.26.0";
 
 /// Timeout for each Socket.IO ack round-trip.
-const ACK_TIMEOUT: Duration = Duration::from_secs(15);
+///
+/// Set generously: `AFFiNE` servers can take 15–25 s to ack the first
+/// `space:join` on a fresh socket (cold-load of the workspace's Yjs state
+/// from persistent storage). Subsequent emits are typically sub-10 ms.
+const ACK_TIMEOUT: Duration = Duration::from_secs(45);
 
 /// Connected Socket.IO client scoped to one `AFFiNE` workspace session.
 pub struct WorkspaceSocket {
@@ -124,7 +128,8 @@ impl WorkspaceSocket {
             "spaceId": workspace_id,
             "docId": doc_id,
         });
-        let ack = self.emit_with_ack("space:load-doc", payload).await?;
+        let raw = self.emit_with_ack("space:load-doc", payload).await?;
+        let ack = unwrap_ack_body(&raw);
 
         if let Some(err_obj) = ack.get("error") {
             let name = err_obj.get("name").and_then(|n| n.as_str()).unwrap_or("");
@@ -138,11 +143,21 @@ impl WorkspaceSocket {
             return Err(ExportError::Transport(format!("space:load-doc: {msg}")));
         }
 
-        let Some(b64) = ack
+        // Accept both server shapes observed in the wild:
+        //   { data: { missing: "…" } }   (documented)
+        //   { missing: "…" }             (un-wrapped)
+        let missing = ack
             .get("data")
             .and_then(|d| d.get("missing"))
-            .and_then(|v| v.as_str())
-        else {
+            .or_else(|| ack.get("missing"))
+            .and_then(|v| v.as_str());
+        let Some(b64) = missing else {
+            debug!(
+                workspace_id,
+                doc_id,
+                ack = %raw,
+                "space:load-doc: no `missing` field in ack"
+            );
             return Ok(None);
         };
         let bytes = base64::engine::general_purpose::STANDARD
@@ -232,7 +247,8 @@ fn ack_debug_shape(ack: &Value) -> String {
 /// Treat the `error` field (if present) of an ack as a transport failure.
 /// Used by events that have no graceful "not found" path.
 fn check_ack_error(event: &'static str, ack: &Value) -> Result<(), ExportError> {
-    if let Some(err_obj) = ack.get("error") {
+    let body = unwrap_ack_body(ack);
+    if let Some(err_obj) = body.get("error") {
         let msg = err_obj
             .get("message")
             .and_then(|m| m.as_str())
@@ -240,4 +256,19 @@ fn check_ack_error(event: &'static str, ack: &Value) -> Result<(), ExportError> 
         return Err(ExportError::Transport(format!("{event}: {msg}")));
     }
     Ok(())
+}
+
+/// Unwrap a single-element JSON array wrapper around an ack body.
+///
+/// `AFFiNE`'s `NestJS` gateway sometimes sends acks as `cb([{…}])` rather
+/// than `cb({…})` — same semantic payload wrapped in a one-element array.
+/// Peel it so downstream `.get("data")` / `.get("error")` calls work
+/// regardless of the wrapper shape.
+fn unwrap_ack_body(ack: &Value) -> &Value {
+    if let Value::Array(items) = ack {
+        if items.len() == 1 {
+            return &items[0];
+        }
+    }
+    ack
 }

--- a/crates/vox-export/src/affine/ydoc.rs
+++ b/crates/vox-export/src/affine/ydoc.rs
@@ -14,7 +14,10 @@
 //! docs only appear in the sidebar once they are registered there — see
 //! [`build_workspace_meta_append`].
 
-use yrs::{Any, Array, ArrayPrelim, Doc, Map, MapPrelim, ReadTxn, Text, Transact, TransactionMut};
+use yrs::{
+    Any, Array, ArrayPrelim, Doc, GetString, Map, MapPrelim, Out, ReadTxn, Text, Transact,
+    TransactionMut, updates::decoder::Decode,
+};
 
 use crate::error::ExportError;
 
@@ -168,6 +171,37 @@ pub fn build_workspace_meta_append(doc_id: &str, title: &str) -> Vec<u8> {
     txn.encode_state_as_update_v1(&yrs::StateVector::default())
 }
 
+/// Extract the human-readable workspace name from a workspace root doc's
+/// Yjs v1 update bytes (as returned by `space:load-doc`).
+///
+/// `AFFiNE` stores the workspace name as a plain string under
+/// `meta.name`; newer clients store it as a `Y.Text`. Both shapes are
+/// handled. Returns `None` if the update cannot be decoded or the field is
+/// absent — callers should fall back to a placeholder (e.g.
+/// [`super::graphql::fallback_workspace_name`]).
+#[must_use]
+pub fn extract_workspace_name(update_bytes: &[u8]) -> Option<String> {
+    let update = yrs::Update::decode_v1(update_bytes).ok()?;
+    let doc = Doc::new();
+    {
+        let mut txn = doc.transact_mut();
+        txn.apply_update(update).ok()?;
+    }
+    let meta = doc.get_or_insert_map("meta");
+    let txn = doc.transact();
+    match meta.get(&txn, "name") {
+        Some(Out::Any(Any::String(s))) => {
+            let owned = s.to_string();
+            if owned.is_empty() { None } else { Some(owned) }
+        }
+        Some(Out::YText(text)) => {
+            let owned = text.get_string(&txn);
+            if owned.is_empty() { None } else { Some(owned) }
+        }
+        _ => None,
+    }
+}
+
 /// Build an `affine:embed-linked-doc` block appended to `parent_doc_id`'s
 /// content, pointing at `child_doc_id`.
 ///
@@ -232,6 +266,63 @@ mod tests {
     fn embed_linked_doc_is_non_empty() {
         let u = build_embed_linked_doc_block("parent", "child").expect("build");
         assert!(!u.is_empty());
+    }
+
+    #[test]
+    fn extract_workspace_name_reads_plain_string() {
+        // Build a synthetic workspace root doc with `meta.name` set as a
+        // plain string, encode it, then confirm extract_workspace_name
+        // reads it back.
+        let doc = Doc::new();
+        let meta = doc.get_or_insert_map("meta");
+        {
+            let mut txn = doc.transact_mut();
+            meta.insert(&mut txn, "name", "My Workspace");
+        }
+        let bytes = doc
+            .transact()
+            .encode_state_as_update_v1(&yrs::StateVector::default());
+
+        assert_eq!(
+            extract_workspace_name(&bytes).as_deref(),
+            Some("My Workspace")
+        );
+    }
+
+    #[test]
+    fn extract_workspace_name_reads_ytext_value() {
+        // Some AFFiNE clients store the name as a Y.Text instead of a plain
+        // string. Confirm we handle both.
+        let doc = Doc::new();
+        let meta = doc.get_or_insert_map("meta");
+        {
+            let mut txn = doc.transact_mut();
+            let text = meta.insert(&mut txn, "name", yrs::TextPrelim::new(""));
+            text.insert(&mut txn, 0, "Rich Name");
+        }
+        let bytes = doc
+            .transact()
+            .encode_state_as_update_v1(&yrs::StateVector::default());
+
+        assert_eq!(extract_workspace_name(&bytes).as_deref(), Some("Rich Name"));
+    }
+
+    #[test]
+    fn extract_workspace_name_absent_returns_none() {
+        // A doc with no `meta.name` at all.
+        let doc = Doc::new();
+        {
+            let _ = doc.get_or_insert_map("meta");
+        }
+        let bytes = doc
+            .transact()
+            .encode_state_as_update_v1(&yrs::StateVector::default());
+        assert!(extract_workspace_name(&bytes).is_none());
+    }
+
+    #[test]
+    fn extract_workspace_name_rejects_malformed_bytes() {
+        assert!(extract_workspace_name(b"not a yjs update").is_none());
     }
 
     #[test]

--- a/crates/vox-export/src/affine/ydoc.rs
+++ b/crates/vox-export/src/affine/ydoc.rs
@@ -181,24 +181,52 @@ pub fn build_workspace_meta_append(doc_id: &str, title: &str) -> Vec<u8> {
 /// [`super::graphql::fallback_workspace_name`]).
 #[must_use]
 pub fn extract_workspace_name(update_bytes: &[u8]) -> Option<String> {
-    let update = yrs::Update::decode_v1(update_bytes).ok()?;
+    let update = match yrs::Update::decode_v1(update_bytes) {
+        Ok(u) => u,
+        Err(e) => {
+            tracing::debug!(error = %e, bytes = update_bytes.len(),
+                "workspace-name: failed to decode yjs update v1");
+            return None;
+        }
+    };
     let doc = Doc::new();
     {
         let mut txn = doc.transact_mut();
-        txn.apply_update(update).ok()?;
+        if let Err(e) = txn.apply_update(update) {
+            tracing::debug!(error = %e, "workspace-name: failed to apply yjs update");
+            return None;
+        }
     }
     let meta = doc.get_or_insert_map("meta");
     let txn = doc.transact();
+
+    // Log every top-level key in `meta` so that if `name` is absent in the
+    // real-world payload (newer AFFiNE schema?) we have breadcrumbs.
+    if tracing::enabled!(tracing::Level::DEBUG) {
+        let keys: Vec<String> = meta.iter(&txn).map(|(k, _)| k.to_owned()).collect();
+        tracing::debug!(keys = ?keys, "workspace-name: meta map keys");
+    }
+
     match meta.get(&txn, "name") {
         Some(Out::Any(Any::String(s))) => {
             let owned = s.to_string();
+            tracing::debug!(name = %owned, "workspace-name: read Any::String from meta.name");
             if owned.is_empty() { None } else { Some(owned) }
         }
         Some(Out::YText(text)) => {
             let owned = text.get_string(&txn);
+            tracing::debug!(name = %owned, "workspace-name: read Y.Text from meta.name");
             if owned.is_empty() { None } else { Some(owned) }
         }
-        _ => None,
+        Some(other) => {
+            tracing::debug!(kind = ?std::mem::discriminant(&other),
+                "workspace-name: meta.name present but not a string/text");
+            None
+        }
+        None => {
+            tracing::debug!("workspace-name: meta.name missing");
+            None
+        }
     }
 }
 

--- a/crates/vox-export/src/affine/ydoc.rs
+++ b/crates/vox-export/src/affine/ydoc.rs
@@ -1,0 +1,251 @@
+//! Yjs-CRDT building blocks for `AFFiNE`'s document format.
+//!
+//! `AFFiNE` stores each document as a Yjs `Doc` with two top-level maps:
+//!
+//! - `blocks` — keyed by block id, each value is a `Y.Map` with
+//!   `sys:id`, `sys:flavour`, `sys:version`, `sys:parent`, `sys:children`,
+//!   plus flavour-specific `prop:*` fields. The root flavour is
+//!   `affine:page`, with `affine:surface` (required sibling) and
+//!   `affine:note` (content container) underneath.
+//! - `meta` — per-doc metadata (`id`, `title`, `createDate`, `tags`).
+//!
+//! Each workspace also has its own root doc (stored under the workspace id
+//! itself) whose `meta.pages` array lists every doc in the workspace. New
+//! docs only appear in the sidebar once they are registered there — see
+//! [`build_workspace_meta_append`].
+
+use yrs::{Any, Array, ArrayPrelim, Doc, Map, MapPrelim, ReadTxn, Text, Transact, TransactionMut};
+
+use crate::error::ExportError;
+
+// `AFFiNE` block schema version numbers, mirroring the constants used by the
+// TypeScript implementation as of Affine 0.26.
+const VERSION_PAGE: i64 = 2;
+const VERSION_SURFACE: i64 = 5;
+const VERSION_NOTE: i64 = 1;
+const VERSION_PARAGRAPH: i64 = 1;
+const VERSION_EMBED_LINKED_DOC: i64 = 1;
+
+/// Set the Yjs-CRDT `sys:id`, `sys:flavour`, `sys:version`, `sys:parent`
+/// fields that every `AFFiNE` block carries.
+fn set_sys_fields(
+    txn: &mut TransactionMut<'_>,
+    block: &yrs::MapRef,
+    id: &str,
+    flavour: &str,
+    version: i64,
+) {
+    block.insert(txn, "sys:id", id);
+    block.insert(txn, "sys:flavour", flavour);
+    block.insert(txn, "sys:version", version);
+    block.insert(txn, "sys:parent", Any::Null);
+}
+
+/// Build a fresh `AFFiNE` document as a Yjs v1 update ready to be pushed via
+/// `space:push-doc-update`.
+///
+/// The document contains a page → surface + note hierarchy, and if
+/// `content_markdown` is non-empty, a single paragraph block holding the
+/// markdown as plain text.
+///
+/// # Errors
+///
+/// Returns [`ExportError::Transport`] only if the underlying yrs transaction
+/// cannot be opened — practically infallible for a fresh in-memory doc.
+pub fn build_doc_update(
+    doc_id: &str,
+    title: &str,
+    content_markdown: &str,
+) -> Result<Vec<u8>, ExportError> {
+    let doc = Doc::new();
+    let blocks = doc.get_or_insert_map("blocks");
+    let meta = doc.get_or_insert_map("meta");
+
+    let page_id = uuid::Uuid::new_v4().to_string();
+    let surface_id = uuid::Uuid::new_v4().to_string();
+    let note_id = uuid::Uuid::new_v4().to_string();
+
+    {
+        let mut txn = doc.transact_mut();
+
+        // ── affine:page (root) ───────────────────────────────────────────
+        let page = blocks.insert(&mut txn, page_id.as_str(), MapPrelim::default());
+        set_sys_fields(&mut txn, &page, &page_id, "affine:page", VERSION_PAGE);
+        let title_text = page.insert(&mut txn, "prop:title", yrs::TextPrelim::new(""));
+        title_text.insert(&mut txn, 0, title);
+        let page_children: yrs::ArrayRef =
+            page.insert(&mut txn, "sys:children", ArrayPrelim::default());
+
+        // ── affine:surface (required sibling) ────────────────────────────
+        let surface = blocks.insert(&mut txn, surface_id.as_str(), MapPrelim::default());
+        set_sys_fields(
+            &mut txn,
+            &surface,
+            &surface_id,
+            "affine:surface",
+            VERSION_SURFACE,
+        );
+        surface.insert(&mut txn, "sys:children", ArrayPrelim::default());
+        let elements = surface.insert(&mut txn, "prop:elements", MapPrelim::default());
+        elements.insert(&mut txn, "type", "$blocksuite:internal:native$");
+        elements.insert(&mut txn, "value", MapPrelim::default());
+        page_children.push_back(&mut txn, surface_id.clone());
+
+        // ── affine:note (content container) ──────────────────────────────
+        let note = blocks.insert(&mut txn, note_id.as_str(), MapPrelim::default());
+        set_sys_fields(&mut txn, &note, &note_id, "affine:note", VERSION_NOTE);
+        note.insert(&mut txn, "prop:displayMode", "both");
+        note.insert(&mut txn, "prop:xywh", "[0,0,800,95]");
+        note.insert(&mut txn, "prop:index", "a0");
+        note.insert(&mut txn, "prop:hidden", false);
+        let bg = note.insert(&mut txn, "prop:background", MapPrelim::default());
+        bg.insert(&mut txn, "light", "#ffffff");
+        bg.insert(&mut txn, "dark", "#252525");
+        let note_children: yrs::ArrayRef =
+            note.insert(&mut txn, "sys:children", ArrayPrelim::default());
+        page_children.push_back(&mut txn, note_id.clone());
+
+        // ── one affine:paragraph with the markdown body ──────────────────
+        if !content_markdown.is_empty() {
+            let para_id = uuid::Uuid::new_v4().to_string();
+            let para = blocks.insert(&mut txn, para_id.as_str(), MapPrelim::default());
+            set_sys_fields(
+                &mut txn,
+                &para,
+                &para_id,
+                "affine:paragraph",
+                VERSION_PARAGRAPH,
+            );
+            para.insert(&mut txn, "sys:children", ArrayPrelim::default());
+            para.insert(&mut txn, "prop:type", "text");
+            let text = para.insert(&mut txn, "prop:text", yrs::TextPrelim::new(""));
+            text.insert(&mut txn, 0, content_markdown);
+            note_children.push_back(&mut txn, para_id);
+        }
+
+        // ── meta ────────────────────────────────────────────────────────
+        meta.insert(&mut txn, "id", doc_id);
+        meta.insert(&mut txn, "title", title);
+        meta.insert(
+            &mut txn,
+            "createDate",
+            chrono::Utc::now().timestamp_millis(),
+        );
+        meta.insert(&mut txn, "tags", ArrayPrelim::default());
+    }
+
+    let txn = doc.transact();
+    let state_vec = yrs::StateVector::default();
+    Ok(txn.encode_state_as_update_v1(&state_vec))
+}
+
+/// Build a workspace-meta delta that appends `{id, title, createDate, tags}`
+/// to the workspace's root doc's `meta.pages` array so the new doc appears
+/// in the sidebar.
+///
+/// Unlike [`build_doc_update`], this produces an update for an existing Yjs
+/// doc — callers apply it by diffing against an empty state vector because
+/// the client did not previously know the workspace doc's contents.
+#[must_use]
+pub fn build_workspace_meta_append(doc_id: &str, title: &str) -> Vec<u8> {
+    let doc = Doc::new();
+    let meta = doc.get_or_insert_map("meta");
+    {
+        let mut txn = doc.transact_mut();
+        let pages: yrs::ArrayRef = meta.insert(&mut txn, "pages", ArrayPrelim::default());
+        let entry = MapPrelim::default();
+        let entry_ref = pages.push_back(&mut txn, entry);
+        entry_ref.insert(&mut txn, "id", doc_id);
+        entry_ref.insert(&mut txn, "title", title);
+        entry_ref.insert(
+            &mut txn,
+            "createDate",
+            chrono::Utc::now().timestamp_millis(),
+        );
+        entry_ref.insert(&mut txn, "tags", ArrayPrelim::default());
+    }
+    let txn = doc.transact();
+    txn.encode_state_as_update_v1(&yrs::StateVector::default())
+}
+
+/// Build an `affine:embed-linked-doc` block appended to `parent_doc_id`'s
+/// content, pointing at `child_doc_id`.
+///
+/// `AFFiNE` renders these as inline links/cards in the parent doc. Adding one
+/// is how we visually "nest" a new doc under an existing parent.
+///
+/// # Errors
+///
+/// Returns [`ExportError::Transport`] if the yrs transaction cannot open
+/// (practically infallible).
+pub fn build_embed_linked_doc_block(
+    _parent_doc_id: &str,
+    child_doc_id: &str,
+) -> Result<Vec<u8>, ExportError> {
+    let doc = Doc::new();
+    let blocks = doc.get_or_insert_map("blocks");
+
+    let block_id = uuid::Uuid::new_v4().to_string();
+    {
+        let mut txn = doc.transact_mut();
+        let block = blocks.insert(&mut txn, block_id.as_str(), MapPrelim::default());
+        set_sys_fields(
+            &mut txn,
+            &block,
+            &block_id,
+            "affine:embed-linked-doc",
+            VERSION_EMBED_LINKED_DOC,
+        );
+        block.insert(&mut txn, "sys:children", ArrayPrelim::default());
+        block.insert(&mut txn, "prop:pageId", child_doc_id);
+        block.insert(&mut txn, "prop:params", MapPrelim::default());
+    }
+    let txn = doc.transact();
+    Ok(txn.encode_state_as_update_v1(&yrs::StateVector::default()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_doc_update_produces_non_empty_bytes() {
+        let u = build_doc_update("doc1", "Hello", "body here").expect("build");
+        assert!(!u.is_empty());
+        // Yjs v1 updates start with a non-zero structure section length.
+        assert!(u.len() > 10, "update unexpectedly short: {} bytes", u.len());
+    }
+
+    #[test]
+    fn build_doc_update_with_empty_content_still_valid() {
+        let u = build_doc_update("doc1", "Hello", "").expect("build");
+        assert!(!u.is_empty());
+    }
+
+    #[test]
+    fn workspace_meta_append_is_non_empty() {
+        let u = build_workspace_meta_append("doc1", "Hello");
+        assert!(!u.is_empty());
+    }
+
+    #[test]
+    fn embed_linked_doc_is_non_empty() {
+        let u = build_embed_linked_doc_block("parent", "child").expect("build");
+        assert!(!u.is_empty());
+    }
+
+    #[test]
+    fn updates_can_be_applied_to_fresh_doc() {
+        use yrs::updates::decoder::Decode;
+        let update_bytes = build_doc_update("doc1", "T", "body").expect("build");
+        let applied = Doc::new();
+        let mut txn = applied.transact_mut();
+        let update = yrs::Update::decode_v1(&update_bytes).expect("decode");
+        txn.apply_update(update).expect("apply");
+        drop(txn);
+
+        let blocks = applied.get_or_insert_map("blocks");
+        let txn = applied.transact();
+        assert!(blocks.len(&txn) >= 3, "expected at least page/surface/note");
+    }
+}

--- a/crates/vox-export/src/affine/ydoc.rs
+++ b/crates/vox-export/src/affine/ydoc.rs
@@ -230,6 +230,73 @@ pub fn extract_workspace_name(update_bytes: &[u8]) -> Option<String> {
     }
 }
 
+/// One page entry as stored in a workspace root doc's `meta.pages` array.
+///
+/// `AFFiNE` populates each entry with at least `id` and `title`, plus
+/// `createDate` and `tags` (not read here).  Matches the shape produced
+/// by [`build_workspace_meta_append`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspacePage {
+    /// The doc's opaque id (matches the GraphQL `DocType.id`).
+    pub id: String,
+    /// Human-readable title; `None` when the entry has no title set
+    /// (rare — usually a brand-new draft).
+    pub title: Option<String>,
+}
+
+/// Extract every page entry from a workspace root doc's `meta.pages`
+/// array.  Returns an empty vec if `meta.pages` is absent or malformed.
+///
+/// `AFFiNE`'s GraphQL schema exposes doc ids and titles via
+/// `workspace(id).docs`, but on self-hosted instances the `title` field
+/// is often `null`; loading the root doc directly and reading the
+/// authoritative `meta.pages` array gives reliable titles.
+#[must_use]
+pub fn extract_workspace_pages(update_bytes: &[u8]) -> Vec<WorkspacePage> {
+    let Ok(update) = yrs::Update::decode_v1(update_bytes) else {
+        return Vec::new();
+    };
+    let doc = Doc::new();
+    {
+        let mut txn = doc.transact_mut();
+        if txn.apply_update(update).is_err() {
+            return Vec::new();
+        }
+    }
+    let meta = doc.get_or_insert_map("meta");
+    let txn = doc.transact();
+
+    let Some(Out::YArray(pages)) = meta.get(&txn, "pages") else {
+        tracing::debug!("workspace-pages: meta.pages missing or not an array");
+        return Vec::new();
+    };
+
+    let mut out = Vec::with_capacity(pages.len(&txn) as usize);
+    for value in pages.iter(&txn) {
+        let Out::YMap(entry) = value else { continue };
+        let Some(Out::Any(Any::String(id))) = entry.get(&txn, "id") else {
+            continue;
+        };
+        let title = match entry.get(&txn, "title") {
+            Some(Out::Any(Any::String(s))) => {
+                let owned = s.to_string();
+                if owned.is_empty() { None } else { Some(owned) }
+            }
+            Some(Out::YText(text)) => {
+                let owned = text.get_string(&txn);
+                if owned.is_empty() { None } else { Some(owned) }
+            }
+            _ => None,
+        };
+        out.push(WorkspacePage {
+            id: id.to_string(),
+            title,
+        });
+    }
+    tracing::debug!(count = out.len(), "workspace-pages: extracted entries");
+    out
+}
+
 /// Build an `affine:embed-linked-doc` block appended to `parent_doc_id`'s
 /// content, pointing at `child_doc_id`.
 ///
@@ -351,6 +418,48 @@ mod tests {
     #[test]
     fn extract_workspace_name_rejects_malformed_bytes() {
         assert!(extract_workspace_name(b"not a yjs update").is_none());
+    }
+
+    #[test]
+    fn extract_workspace_pages_reads_meta_pages_array() {
+        // Simulate a workspace root doc with two pages in `meta.pages`.
+        let doc = Doc::new();
+        let meta = doc.get_or_insert_map("meta");
+        {
+            let mut txn = doc.transact_mut();
+            let pages: yrs::ArrayRef = meta.insert(&mut txn, "pages", ArrayPrelim::default());
+            let e1 = pages.push_back(&mut txn, MapPrelim::default());
+            e1.insert(&mut txn, "id", "doc-one");
+            e1.insert(&mut txn, "title", "Meeting notes");
+            let e2 = pages.push_back(&mut txn, MapPrelim::default());
+            e2.insert(&mut txn, "id", "doc-two");
+            e2.insert(&mut txn, "title", "");
+        }
+        let bytes = doc
+            .transact()
+            .encode_state_as_update_v1(&yrs::StateVector::default());
+
+        let pages = extract_workspace_pages(&bytes);
+        assert_eq!(pages.len(), 2);
+        assert_eq!(pages[0].id, "doc-one");
+        assert_eq!(pages[0].title.as_deref(), Some("Meeting notes"));
+        assert_eq!(pages[1].id, "doc-two");
+        assert!(pages[1].title.is_none());
+    }
+
+    #[test]
+    fn extract_workspace_pages_empty_when_no_meta_pages() {
+        let doc = Doc::new();
+        let _meta = doc.get_or_insert_map("meta");
+        let bytes = doc
+            .transact()
+            .encode_state_as_update_v1(&yrs::StateVector::default());
+        assert!(extract_workspace_pages(&bytes).is_empty());
+    }
+
+    #[test]
+    fn extract_workspace_pages_rejects_malformed_bytes() {
+        assert!(extract_workspace_pages(b"garbage").is_empty());
     }
 
     #[test]

--- a/crates/vox-export/src/error.rs
+++ b/crates/vox-export/src/error.rs
@@ -1,0 +1,55 @@
+//! Error types for the `vox-export` crate.
+
+use thiserror::Error;
+
+/// Errors that can occur while exporting a session to an external target.
+#[derive(Debug, Error)]
+pub enum ExportError {
+    /// An unknown target id was requested.
+    #[error("unknown export target '{0}'")]
+    UnknownTarget(String),
+
+    /// The target is not configured (e.g. `enabled = false` or missing fields).
+    #[error("export target '{0}' is not configured")]
+    NotConfigured(String),
+
+    /// Authentication against the remote service failed.
+    #[error("authentication failed: {0}")]
+    Auth(String),
+
+    /// A required configuration field is missing or invalid.
+    #[error("configuration error: {0}")]
+    Config(String),
+
+    /// An HTTP request to the remote service failed.
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// The remote API returned a non-success status code.
+    #[error("API returned status {status}: {body}")]
+    ApiError {
+        /// HTTP status code.
+        status: u16,
+        /// Response body text (truncated / sanitized).
+        body: String,
+    },
+
+    /// The API response could not be parsed as expected.
+    #[error("failed to parse API response: {reason}")]
+    ParseError {
+        /// Human-readable explanation of what failed.
+        reason: String,
+    },
+
+    /// The named destination (workspace / folder / parent doc) was not found.
+    #[error("destination not found: {0}")]
+    DestinationNotFound(String),
+
+    /// A realtime (WebSocket / Socket.IO) transport error.
+    #[error("realtime transport error: {0}")]
+    Transport(String),
+
+    /// JSON serialization or deserialization failed.
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+}

--- a/crates/vox-export/src/factory.rs
+++ b/crates/vox-export/src/factory.rs
@@ -1,0 +1,128 @@
+//! Factory for building enabled [`ExportTarget`]s from an [`ExportConfig`].
+
+use vox_core::config::ExportConfig;
+
+use crate::{affine::AffineTarget, error::ExportError, traits::ExportTarget};
+
+/// Construct one boxed [`ExportTarget`] per enabled entry in `config`.
+///
+/// Targets that fail to construct (e.g. missing required fields) are logged
+/// and skipped so that one broken config section does not disable the entire
+/// export subsystem.
+///
+/// # Errors
+///
+/// This function itself cannot fail — individual target construction errors
+/// are logged and swallowed. Callers get whichever targets were built
+/// successfully.
+#[must_use]
+pub fn build_targets(config: &ExportConfig) -> Vec<Box<dyn ExportTarget>> {
+    let mut out: Vec<Box<dyn ExportTarget>> = Vec::new();
+
+    if config.affine.enabled {
+        match AffineTarget::from_config(&config.affine) {
+            Ok(target) => out.push(Box::new(target)),
+            Err(e) => {
+                tracing::warn!(error = %e, "affine export target disabled due to config error");
+            }
+        }
+    }
+
+    out
+}
+
+/// Build a single [`ExportTarget`] by id.
+///
+/// Used by the GUI when the user picks a specific target from the Send-to
+/// modal without re-enumerating the full list.
+///
+/// # Errors
+///
+/// - [`ExportError::UnknownTarget`] when `id` is not a known target.
+/// - [`ExportError::NotConfigured`] when the target exists but its config
+///   section is disabled.
+/// - [`ExportError::Config`] when required fields are missing.
+pub fn build_target_by_id(
+    id: &str,
+    config: &ExportConfig,
+) -> Result<Box<dyn ExportTarget>, ExportError> {
+    match id {
+        "affine" => {
+            if !config.affine.enabled {
+                return Err(ExportError::NotConfigured("affine".to_owned()));
+            }
+            Ok(Box::new(AffineTarget::from_config(&config.affine)?))
+        }
+        other => Err(ExportError::UnknownTarget(other.to_owned())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vox_core::config::{AffineExportConfig, ExportConfig};
+
+    fn disabled_config() -> ExportConfig {
+        ExportConfig::default()
+    }
+
+    fn enabled_config() -> ExportConfig {
+        ExportConfig {
+            affine: AffineExportConfig {
+                enabled: true,
+                base_url: "https://app.affine.pro".to_owned(),
+                api_token: "ut_test".to_owned(),
+                email: String::new(),
+                password: String::new(),
+                default_workspace_id: String::new(),
+                default_parent_id: String::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn build_targets_empty_when_affine_disabled() {
+        let targets = build_targets(&disabled_config());
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn build_targets_includes_affine_when_enabled() {
+        let targets = build_targets(&enabled_config());
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].id(), "affine");
+    }
+
+    #[test]
+    fn build_target_by_id_unknown_returns_error() {
+        let config = enabled_config();
+        assert!(matches!(
+            build_target_by_id("notion", &config),
+            Err(ExportError::UnknownTarget(_))
+        ));
+    }
+
+    #[test]
+    fn build_target_by_id_disabled_returns_not_configured() {
+        let config = disabled_config();
+        assert!(matches!(
+            build_target_by_id("affine", &config),
+            Err(ExportError::NotConfigured(_))
+        ));
+    }
+
+    #[test]
+    fn build_target_by_id_missing_auth_returns_config_error() {
+        let config = ExportConfig {
+            affine: AffineExportConfig {
+                enabled: true,
+                base_url: "https://app.affine.pro".to_owned(),
+                ..AffineExportConfig::default()
+            },
+        };
+        assert!(matches!(
+            build_target_by_id("affine", &config),
+            Err(ExportError::Config(_))
+        ));
+    }
+}

--- a/crates/vox-export/src/lib.rs
+++ b/crates/vox-export/src/lib.rs
@@ -1,0 +1,34 @@
+#![warn(clippy::all, clippy::pedantic)]
+
+//! Plugin-based exporter framework for Vox Daemon.
+//!
+//! # Overview
+//!
+//! This crate lets Vox Daemon push transcripts and summaries out to third-party
+//! knowledgebases. The first (and currently only) implementation is
+//! [`affine::AffineTarget`], which pushes sessions into an `AFFiNE` workspace.
+//!
+//! # Plugin shape
+//!
+//! An export "plugin" is any type implementing [`traits::ExportTarget`]. The
+//! GUI discovers enabled targets via [`factory::build_targets`], which reads
+//! [`vox_core::config::ExportConfig`] and returns one boxed trait object per
+//! enabled target.
+//!
+//! # Module layout
+//!
+//! | Module | Purpose |
+//! |--------|---------|
+//! | [`error`] | [`ExportError`] enum shared across all targets |
+//! | [`traits`] | [`ExportTarget`] trait + request/response types |
+//! | [`factory`] | [`build_targets`](factory::build_targets) factory function |
+//! | [`affine`] | `AFFiNE` (cloud + self-hosted) target implementation |
+
+pub mod affine;
+pub mod error;
+pub mod factory;
+pub mod traits;
+
+pub use error::ExportError;
+pub use factory::build_targets;
+pub use traits::{ExportRequest, ExportResult, ExportTarget, Folder, Workspace};

--- a/crates/vox-export/src/traits.rs
+++ b/crates/vox-export/src/traits.rs
@@ -1,0 +1,120 @@
+//! Core trait and DTOs for third-party export targets.
+
+use async_trait::async_trait;
+use vox_core::session::Session;
+
+use crate::error::ExportError;
+
+/// A top-level container on the remote service (e.g. an `AFFiNE` workspace,
+/// a Notion workspace, a Google Drive account).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Workspace {
+    /// Opaque identifier used by the target to refer to this container.
+    pub id: String,
+    /// Human-readable display name for UI pickers.
+    pub name: String,
+}
+
+impl std::fmt::Display for Workspace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.name)
+    }
+}
+
+/// A nested destination within a [`Workspace`] (e.g. an `AFFiNE` parent doc,
+/// a Notion page, a Drive folder).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Folder {
+    /// Opaque identifier used by the target to refer to this folder.
+    pub id: String,
+    /// Human-readable title shown in UI pickers.
+    pub title: String,
+}
+
+impl std::fmt::Display for Folder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.title)
+    }
+}
+
+/// Arguments for [`ExportTarget::export`].
+///
+/// Borrows the session and pre-rendered Markdown rather than owning them so
+/// callers can reuse the same data for multiple targets without clones.
+pub struct ExportRequest<'a> {
+    /// Workspace to write into.
+    pub workspace_id: String,
+    /// Optional parent folder inside the workspace. `None` means the workspace
+    /// root.
+    pub parent_id: Option<String>,
+    /// User-chosen title for the new remote document.
+    pub title: String,
+    /// Markdown body, pre-rendered via `vox_storage::render_export`.
+    pub content_markdown: &'a str,
+    /// Full session, available if the target wants to include metadata (date,
+    /// duration, participants, etc.) beyond the rendered Markdown.
+    pub session: &'a Session,
+}
+
+/// Result of a successful export.
+#[derive(Debug, Clone)]
+pub struct ExportResult {
+    /// Opaque identifier of the newly created remote document.
+    pub remote_id: String,
+    /// Clickable URL, if the target can construct one. Surfaced in the
+    /// success notification.
+    pub remote_url: Option<String>,
+}
+
+/// Trait that every export plugin implements.
+///
+/// Implementations must be `Send + Sync` to be usable across Tokio task
+/// boundaries and shared from the GUI state.
+#[async_trait]
+pub trait ExportTarget: Send + Sync {
+    /// Stable, machine-friendly identifier for this target (e.g. `"affine"`).
+    fn id(&self) -> &'static str;
+
+    /// Human-readable display name for UI pickers (e.g. `"AFFiNE"`).
+    fn display_name(&self) -> &'static str;
+
+    /// List top-level containers (workspaces) available to the authenticated
+    /// user.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExportError`] on auth failure, transport failure, or when the
+    /// remote response cannot be parsed.
+    async fn list_workspaces(&self) -> Result<Vec<Workspace>, ExportError>;
+
+    /// List folders (parent docs / pages / directories) within the given
+    /// workspace.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExportError`] on auth failure, transport failure, or when the
+    /// workspace id is unknown.
+    async fn list_folders(&self, workspace_id: &str) -> Result<Vec<Folder>, ExportError>;
+
+    /// Create a new folder inside the given workspace, optionally under an
+    /// existing parent folder.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExportError`] on auth failure or if the parent cannot be
+    /// located.
+    async fn create_folder(
+        &self,
+        workspace_id: &str,
+        parent_id: Option<&str>,
+        title: &str,
+    ) -> Result<Folder, ExportError>;
+
+    /// Push a session to the remote service as a new document.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExportError`] if auth fails, the document cannot be created,
+    /// or the remote rejects the content.
+    async fn export(&self, request: ExportRequest<'_>) -> Result<ExportResult, ExportError>;
+}

--- a/crates/vox-export/tests/affine_http.rs
+++ b/crates/vox-export/tests/affine_http.rs
@@ -1,0 +1,160 @@
+//! HTTP-surface integration tests for the AFFiNE target.
+//!
+//! These tests exercise everything up to (and excluding) the Socket.IO / Yjs
+//! doc-push step, which is stubbed by AFFiNE and therefore not reachable from
+//! a simple mock. The realtime layer is covered by unit tests in the
+//! `ydoc` module and will need real-backend QA for final verification.
+
+use serde_json::json;
+use vox_core::config::AffineExportConfig;
+use vox_export::{ExportError, ExportTarget, affine::AffineTarget};
+use wiremock::matchers::{body_json, header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn cfg(base_url: &str) -> AffineExportConfig {
+    AffineExportConfig {
+        enabled: true,
+        base_url: base_url.to_owned(),
+        email: "user@example.com".to_owned(),
+        password: "hunter2".to_owned(),
+        ..AffineExportConfig::default()
+    }
+}
+
+#[tokio::test]
+async fn list_workspaces_uses_bearer_token_and_parses_response() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .and(header("Authorization", "Bearer ut_abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "workspaces": [
+                { "id": "ws-1", "public": false },
+                { "id": "ws-2", "public": true }
+            ]}
+        })))
+        .mount(&server)
+        .await;
+
+    let target = AffineTarget::from_config(&AffineExportConfig {
+        enabled: true,
+        base_url: server.uri(),
+        api_token: "ut_abc".to_owned(),
+        ..AffineExportConfig::default()
+    })
+    .expect("build target");
+
+    let workspaces = target.list_workspaces().await.expect("list");
+    assert_eq!(workspaces.len(), 2);
+    assert_eq!(workspaces[0].id, "ws-1");
+    assert!(workspaces[0].name.contains("ws-1") || workspaces[0].name.starts_with("Workspace "));
+}
+
+#[tokio::test]
+async fn list_workspaces_surfaces_graphql_errors() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": null,
+            "errors": [{ "message": "forbidden" }]
+        })))
+        .mount(&server)
+        .await;
+
+    let target = AffineTarget::from_config(&AffineExportConfig {
+        enabled: true,
+        base_url: server.uri(),
+        api_token: "t".to_owned(),
+        ..AffineExportConfig::default()
+    })
+    .expect("build");
+
+    let err = target
+        .list_workspaces()
+        .await
+        .expect_err("should propagate graphql error");
+    match err {
+        ExportError::ApiError { body, .. } => assert_eq!(body, "forbidden"),
+        other => panic!("expected ApiError, got {other}"),
+    }
+}
+
+#[tokio::test]
+async fn password_login_exchanges_credentials_for_cookie() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/auth/sign-in"))
+        .and(body_json(json!({
+            "email": "user@example.com",
+            "password": "hunter2"
+        })))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .append_header("Set-Cookie", "affine_session=sess_42; Path=/; HttpOnly"),
+        )
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .and(header("Cookie", "affine_session=sess_42"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "workspaces": [{ "id": "ws-only", "public": false }] }
+        })))
+        .mount(&server)
+        .await;
+
+    let target = AffineTarget::from_config(&cfg(&server.uri())).expect("build");
+    let workspaces = target.list_workspaces().await.expect("list");
+    assert_eq!(workspaces.len(), 1);
+    assert_eq!(workspaces[0].id, "ws-only");
+}
+
+#[tokio::test]
+async fn list_folders_pages_through_docs_query() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "workspace": { "docs": { "edges": [
+                { "node": { "id": "d1", "title": "Notes" } },
+                { "node": { "id": "d2", "title": null } }
+            ]}}}
+        })))
+        .mount(&server)
+        .await;
+
+    let target = AffineTarget::from_config(&AffineExportConfig {
+        enabled: true,
+        base_url: server.uri(),
+        api_token: "t".to_owned(),
+        ..AffineExportConfig::default()
+    })
+    .expect("build");
+
+    let folders = target.list_folders("ws-1").await.expect("list");
+    assert_eq!(folders.len(), 2);
+    assert_eq!(folders[0].id, "d1");
+    assert_eq!(folders[0].title, "Notes");
+    assert_eq!(folders[1].title, "Untitled");
+}
+
+#[tokio::test]
+async fn failed_sign_in_maps_to_auth_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/auth/sign-in"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("bad creds"))
+        .mount(&server)
+        .await;
+
+    let target = AffineTarget::from_config(&cfg(&server.uri())).expect("build");
+    match target.list_workspaces().await {
+        Err(ExportError::Auth(msg)) => assert!(msg.contains("401"), "unexpected: {msg}"),
+        other => panic!("expected Auth error, got {other:?}"),
+    }
+}

--- a/crates/vox-export/tests/affine_http.rs
+++ b/crates/vox-export/tests/affine_http.rs
@@ -113,35 +113,10 @@ async fn password_login_exchanges_credentials_for_cookie() {
     assert_eq!(workspaces[0].id, "ws-only");
 }
 
-#[tokio::test]
-async fn list_folders_pages_through_docs_query() {
-    let server = MockServer::start().await;
-
-    Mock::given(method("POST"))
-        .and(path("/graphql"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "data": { "workspace": { "docs": { "edges": [
-                { "node": { "id": "d1", "title": "Notes" } },
-                { "node": { "id": "d2", "title": null } }
-            ]}}}
-        })))
-        .mount(&server)
-        .await;
-
-    let target = AffineTarget::from_config(&AffineExportConfig {
-        enabled: true,
-        base_url: server.uri(),
-        api_token: "t".to_owned(),
-        ..AffineExportConfig::default()
-    })
-    .expect("build");
-
-    let folders = target.list_folders("ws-1").await.expect("list");
-    assert_eq!(folders.len(), 2);
-    assert_eq!(folders[0].id, "d1");
-    assert_eq!(folders[0].title, "Notes");
-    assert_eq!(folders[1].title, "Untitled");
-}
+// list_folders previously used GraphQL but now loads the workspace root
+// Yjs doc via Socket.IO (real titles live there, not in GraphQL). The
+// realtime path has no HTTP-mock-equivalent; it's covered by the ydoc
+// unit tests (`extract_workspace_pages_*`).
 
 #[tokio::test]
 async fn failed_sign_in_maps_to_auth_error() {

--- a/crates/vox-gui/Cargo.toml
+++ b/crates/vox-gui/Cargo.toml
@@ -11,6 +11,7 @@ vox-core = { workspace = true }
 vox-storage = { workspace = true }
 vox-capture = { workspace = true }
 vox-summarize = { workspace = true }
+vox-export = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/vox-gui/src/app.rs
+++ b/crates/vox-gui/src/app.rs
@@ -18,7 +18,7 @@
 //! - [`Page::Settings`] — settings form backed by [`SettingsModel`]
 //! - [`Page::Browser`] — transcript list + detail viewer with search
 
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 use iced::widget::rule;
 use iced::widget::{
@@ -29,6 +29,9 @@ use tracing::{error, info, warn};
 use uuid::Uuid;
 use vox_core::config::AppConfig;
 use vox_core::session::{Session, Summary};
+use vox_export::{
+    ExportRequest, ExportResult, ExportTarget, Folder as ExportFolder, Workspace as ExportWorkspace,
+};
 use vox_storage::store::{JsonFileStore, SessionStore};
 
 use crate::browser::{SessionListEntry, build_session_list};
@@ -150,6 +153,18 @@ pub enum Message {
     /// The export format pick-list changed.
     ExportFormatChanged(ExportFormat),
 
+    // ── Settings: Export (Affine) ────────────────────────────────────
+    /// The `AFFiNE`export enabled toggle changed.
+    AffineEnabledToggled(bool),
+    /// The `AFFiNE`base URL text field changed.
+    AffineBaseUrlChanged(String),
+    /// The `AFFiNE`API token text field changed.
+    AffineApiTokenChanged(String),
+    /// The `AFFiNE`login email text field changed.
+    AffineEmailChanged(String),
+    /// The `AFFiNE`login password text field changed.
+    AffinePasswordChanged(String),
+
     // ── Settings: Notifications ──────────────────────────────────────────────
     /// Master notifications toggle changed.
     NotificationsEnabledToggled(bool),
@@ -203,6 +218,36 @@ pub enum Message {
     /// Speaker names were persisted to disk (carries success flag).
     SpeakerNamesSaved(bool),
 
+    // ── Browser: send-to (plugin export) ─────────────────────────────
+    /// Open the Send-to modal — triggers `list_workspaces` on the target.
+    OpenSendToModal,
+    /// Close the Send-to modal without sending.
+    CloseSendToModal,
+    /// Document-title text field in the Send-to modal changed.
+    SendToTitleChanged(String),
+    /// Content pick-list in the Send-to modal changed.
+    SendToContentChanged(ExportContent),
+    /// Workspace list finished loading.
+    SendToWorkspacesLoaded(Result<Vec<ExportWorkspace>, String>),
+    /// User chose a workspace in the Send-to modal.
+    SendToWorkspaceSelected(ExportWorkspace),
+    /// Folder list finished loading.
+    SendToFoldersLoaded(Result<Vec<ExportFolder>, String>),
+    /// User picked a folder (parent doc) or `None` for workspace root.
+    SendToFolderSelected(Option<ExportFolder>),
+    /// Toggle between "pick existing folder" and "create new folder" modes.
+    SendToCreateFolderToggle,
+    /// New-folder title text field changed.
+    SendToCreateFolderTitleChanged(String),
+    /// Commit the new-folder creation (calls `target.create_folder`).
+    SendToCreateFolderCommit,
+    /// New folder creation finished.
+    SendToFolderCreated(Result<ExportFolder, String>),
+    /// User confirmed the send — triggers `target.export`.
+    ConfirmSendTo,
+    /// Send finished; carries the remote URL (on success) or an error message.
+    SendToResult(Result<String, String>),
+
     // ── Browser: summarization ───────────────────────────────────────────
     /// The user requested manual AI summary generation for the selected session.
     GenerateSummary,
@@ -230,6 +275,83 @@ impl Default for ExportModalState {
         Self {
             content: ExportContent::TranscriptAndSummary,
             format: ExportFormat::Markdown,
+        }
+    }
+}
+
+/// State for the Send-to modal overlay (plugin-based export).
+///
+/// One `SendToModalState` exists per open-and-send interaction. The enabled
+/// target (`target`) is cloned in each request to allow concurrent background
+/// loads (workspace list, folder list, send) while the user continues
+/// interacting with the modal.
+#[allow(clippy::struct_excessive_bools)]
+pub struct SendToModalState {
+    /// The plugin target the user is sending to. Currently always `AffineTarget`.
+    pub target: Arc<dyn ExportTarget>,
+    /// User-editable document title.
+    pub title: String,
+    /// Which content to include in the rendered Markdown.
+    pub content: ExportContent,
+    /// All workspaces visible on the remote service.
+    pub workspaces: Vec<ExportWorkspace>,
+    /// `true` while a workspace load is in flight.
+    pub workspaces_loading: bool,
+    /// The selected workspace.
+    pub selected_workspace: Option<ExportWorkspace>,
+    /// All folders (parent docs) within the selected workspace.
+    pub folders: Vec<ExportFolder>,
+    /// `true` while a folder load is in flight.
+    pub folders_loading: bool,
+    /// The selected folder, or `None` for "workspace root".
+    pub selected_folder: Option<ExportFolder>,
+    /// `true` when the user is typing a new folder name.
+    pub creating_folder: bool,
+    /// Title of the folder being created.
+    pub new_folder_title: String,
+    /// `true` while the final send is in flight.
+    pub sending: bool,
+    /// Last error message (if any) to surface inline.
+    pub error: Option<String>,
+}
+
+impl std::fmt::Debug for SendToModalState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `target` is a trait object so we cannot derive Debug; print its id
+        // and a summary of the interesting state. `finish_non_exhaustive`
+        // keeps the lint happy without forcing us to enumerate every field.
+        f.debug_struct("SendToModalState")
+            .field("target", &self.target.id())
+            .field("title", &self.title)
+            .field("workspaces", &self.workspaces.len())
+            .field("folders", &self.folders.len())
+            .field("sending", &self.sending)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SendToModalState {
+    /// Construct a fresh modal for the given target and default values.
+    #[must_use]
+    pub fn new(
+        target: Arc<dyn ExportTarget>,
+        default_title: String,
+        default_content: ExportContent,
+    ) -> Self {
+        Self {
+            target,
+            title: default_title,
+            content: default_content,
+            workspaces: Vec::new(),
+            workspaces_loading: true,
+            selected_workspace: None,
+            folders: Vec::new(),
+            folders_loading: false,
+            selected_folder: None,
+            creating_folder: false,
+            new_folder_title: String::new(),
+            sending: false,
+            error: None,
         }
     }
 }
@@ -279,6 +401,9 @@ pub struct VoxAppState {
 
     /// When `Some`, the export modal is open.
     pub export_modal: Option<ExportModalState>,
+
+    /// When `Some`, the Send-to (plugin export) modal is open.
+    pub send_to_modal: Option<SendToModalState>,
 }
 
 impl VoxAppState {
@@ -344,6 +469,7 @@ impl VoxAppState {
             browser_status: None,
             summarizing: false,
             export_modal: None,
+            send_to_modal: None,
         }
     }
 
@@ -461,6 +587,28 @@ pub fn update(state: &mut VoxAppState, message: Message) -> Task<Message> {
         }
         Message::ExportFormatChanged(f) => {
             state.settings.storage.export_format = f;
+            Task::none()
+        }
+
+        // ── Export settings (Affine) ──────────────────────────────────────
+        Message::AffineEnabledToggled(v) => {
+            state.settings.export.affine.enabled = v;
+            Task::none()
+        }
+        Message::AffineBaseUrlChanged(s) => {
+            state.settings.export.affine.base_url = s;
+            Task::none()
+        }
+        Message::AffineApiTokenChanged(s) => {
+            state.settings.export.affine.api_token = s;
+            Task::none()
+        }
+        Message::AffineEmailChanged(s) => {
+            state.settings.export.affine.email = s;
+            Task::none()
+        }
+        Message::AffinePasswordChanged(s) => {
+            state.settings.export.affine.password = s;
             Task::none()
         }
 
@@ -698,6 +846,225 @@ pub fn update(state: &mut VoxAppState, message: Message) -> Task<Message> {
             Task::none()
         }
 
+        // ── Browser: send-to (plugin export) ─────────────────────────
+        Message::OpenSendToModal => {
+            let Some(ref session) = state.selected_session else {
+                return Task::none();
+            };
+            let config = state.settings.to_config();
+            let mut targets = vox_export::build_targets(&config.export);
+            if targets.is_empty() {
+                state.browser_status = Some(
+                    "No export targets enabled — configure one in Settings → Export.".to_owned(),
+                );
+                return Task::none();
+            }
+            let target: Arc<dyn ExportTarget> = Arc::from(targets.remove(0));
+            let default_title = default_export_title(session);
+            let modal = SendToModalState::new(
+                target.clone(),
+                default_title,
+                ExportContent::TranscriptAndSummary,
+            );
+            state.send_to_modal = Some(modal);
+            Task::perform(
+                async move { target.list_workspaces().await.map_err(|e| e.to_string()) },
+                Message::SendToWorkspacesLoaded,
+            )
+        }
+        Message::CloseSendToModal => {
+            state.send_to_modal = None;
+            Task::none()
+        }
+        Message::SendToTitleChanged(t) => {
+            if let Some(ref mut modal) = state.send_to_modal {
+                modal.title = t;
+            }
+            Task::none()
+        }
+        Message::SendToContentChanged(c) => {
+            if let Some(ref mut modal) = state.send_to_modal {
+                modal.content = c;
+            }
+            Task::none()
+        }
+        Message::SendToWorkspacesLoaded(result) => {
+            if let Some(ref mut modal) = state.send_to_modal {
+                modal.workspaces_loading = false;
+                match result {
+                    Ok(ws) => {
+                        modal.workspaces = ws;
+                        modal.error = None;
+                    }
+                    Err(e) => modal.error = Some(format!("Failed to load workspaces: {e}")),
+                }
+            }
+            Task::none()
+        }
+        Message::SendToWorkspaceSelected(ws) => {
+            let Some(ref mut modal) = state.send_to_modal else {
+                return Task::none();
+            };
+            modal.selected_workspace = Some(ws.clone());
+            modal.folders.clear();
+            modal.selected_folder = None;
+            modal.folders_loading = true;
+            let target = modal.target.clone();
+            let ws_id = ws.id;
+            Task::perform(
+                async move { target.list_folders(&ws_id).await.map_err(|e| e.to_string()) },
+                Message::SendToFoldersLoaded,
+            )
+        }
+        Message::SendToFoldersLoaded(result) => {
+            if let Some(ref mut modal) = state.send_to_modal {
+                modal.folders_loading = false;
+                match result {
+                    Ok(fs) => {
+                        modal.folders = fs;
+                        modal.error = None;
+                    }
+                    Err(e) => modal.error = Some(format!("Failed to load folders: {e}")),
+                }
+            }
+            Task::none()
+        }
+        Message::SendToFolderSelected(f) => {
+            if let Some(ref mut modal) = state.send_to_modal {
+                modal.selected_folder = f;
+                modal.creating_folder = false;
+            }
+            Task::none()
+        }
+        Message::SendToCreateFolderToggle => {
+            if let Some(ref mut modal) = state.send_to_modal {
+                modal.creating_folder = !modal.creating_folder;
+                if modal.creating_folder {
+                    modal.selected_folder = None;
+                } else {
+                    modal.new_folder_title.clear();
+                }
+            }
+            Task::none()
+        }
+        Message::SendToCreateFolderTitleChanged(t) => {
+            if let Some(ref mut modal) = state.send_to_modal {
+                modal.new_folder_title = t;
+            }
+            Task::none()
+        }
+        Message::SendToCreateFolderCommit => {
+            let Some(ref modal) = state.send_to_modal else {
+                return Task::none();
+            };
+            let Some(ref ws) = modal.selected_workspace else {
+                return Task::none();
+            };
+            if modal.new_folder_title.trim().is_empty() {
+                return Task::none();
+            }
+            let target = modal.target.clone();
+            let ws_id = ws.id.clone();
+            let title = modal.new_folder_title.clone();
+            Task::perform(
+                async move {
+                    target
+                        .create_folder(&ws_id, None, &title)
+                        .await
+                        .map_err(|e| e.to_string())
+                },
+                Message::SendToFolderCreated,
+            )
+        }
+        Message::SendToFolderCreated(result) => {
+            if let Some(ref mut modal) = state.send_to_modal {
+                match result {
+                    Ok(folder) => {
+                        modal.folders.push(folder.clone());
+                        modal.selected_folder = Some(folder);
+                        modal.creating_folder = false;
+                        modal.new_folder_title.clear();
+                        modal.error = None;
+                    }
+                    Err(e) => modal.error = Some(format!("Failed to create folder: {e}")),
+                }
+            }
+            Task::none()
+        }
+        Message::ConfirmSendTo => {
+            let Some(ref mut modal) = state.send_to_modal else {
+                return Task::none();
+            };
+            let Some(ref session) = state.selected_session else {
+                return Task::none();
+            };
+            let Some(ref ws) = modal.selected_workspace else {
+                modal.error = Some("Pick a workspace first.".to_owned());
+                return Task::none();
+            };
+            if modal.title.trim().is_empty() {
+                modal.error = Some("Title is required.".to_owned());
+                return Task::none();
+            }
+
+            modal.sending = true;
+            modal.error = None;
+
+            let target = modal.target.clone();
+            let title = modal.title.trim().to_owned();
+            let workspace_id = ws.id.clone();
+            let parent_id = modal.selected_folder.as_ref().map(|f| f.id.clone());
+            let include_transcript = matches!(
+                modal.content,
+                ExportContent::Transcript | ExportContent::TranscriptAndSummary
+            );
+            let include_summary = matches!(
+                modal.content,
+                ExportContent::Summary | ExportContent::TranscriptAndSummary
+            );
+            let session = session.clone();
+
+            Task::perform(
+                async move {
+                    let options = vox_storage::RenderOptions {
+                        include_transcript,
+                        include_summary,
+                    };
+                    let markdown = vox_storage::render_export(&session, "markdown", &options)?;
+                    let request = ExportRequest {
+                        workspace_id,
+                        parent_id,
+                        title,
+                        content_markdown: &markdown,
+                        session: &session,
+                    };
+                    let ExportResult {
+                        remote_url,
+                        remote_id,
+                    } = target.export(request).await.map_err(|e| e.to_string())?;
+                    Ok(remote_url.unwrap_or(remote_id))
+                },
+                Message::SendToResult,
+            )
+        }
+        Message::SendToResult(result) => {
+            match result {
+                Ok(url) => {
+                    info!(%url, "send-to export succeeded");
+                    state.send_to_modal = None;
+                    state.browser_status = Some(format!("Sent to {url}"));
+                }
+                Err(e) => {
+                    error!("send-to export failed: {e}");
+                    if let Some(ref mut modal) = state.send_to_modal {
+                        modal.sending = false;
+                        modal.error = Some(e);
+                    }
+                }
+            }
+            Task::none()
+        }
+
         // ── Browser: summarization ───────────────────────────────────────
         Message::GenerateSummary => {
             let Some(ref session) = state.selected_session else {
@@ -781,6 +1148,16 @@ pub fn update(state: &mut VoxAppState, message: Message) -> Task<Message> {
 
 /// Build the widget tree for the current state.
 pub fn view(state: &VoxAppState) -> Element<'_, Message> {
+    // Send-to modal takes over the window when open (checked before export
+    // modal so the two cannot visually stack).
+    if let Some(ref modal) = state.send_to_modal {
+        return container(view_send_to_form(modal))
+            .width(Fill)
+            .height(Fill)
+            .padding(vox_theme::PADDING)
+            .into();
+    }
+
     // When the export form is open, it takes over the entire window.
     if let Some(ref modal) = state.export_modal {
         let has_transcript = state
@@ -903,6 +1280,184 @@ fn view_export_form<'a>(
             export_btn.style(button::primary),
         ]
         .spacing(vox_theme::SPACING),
+    ]
+    .spacing(vox_theme::SECTION_SPACING)
+    .padding(vox_theme::PADDING)
+    .into()
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Send-to (plugin export) view
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Wrapper around an optional folder for the pick-list widget (iced's
+/// `pick_list` wants a single `T: Clone + Eq + Display`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FolderChoice {
+    Root,
+    Existing(ExportFolder),
+}
+
+impl std::fmt::Display for FolderChoice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Root => f.write_str("— Workspace root —"),
+            Self::Existing(folder) => f.write_str(&folder.title),
+        }
+    }
+}
+
+/// Default document title for a session: `meeting-YYYY-MM-DD`.
+fn default_export_title(session: &Session) -> String {
+    let date = session.created_at.format("%Y-%m-%d").to_string();
+    format!("meeting-{date}")
+}
+
+#[allow(clippy::too_many_lines)]
+fn view_send_to_form(modal: &SendToModalState) -> Element<'_, Message> {
+    let header = text(format!("Send to {}", modal.target.display_name())).size(16u32);
+
+    // ── Title ────────────────────────────────────────────────────────────
+    let title_field = column![
+        text("Document title").size(12u32),
+        text_input("meeting-YYYY-MM-DD", &modal.title)
+            .on_input(Message::SendToTitleChanged)
+            .width(Fill),
+    ]
+    .spacing(4);
+
+    // ── Content toggle (reuses the existing enum) ────────────────────────
+    let content_field = column![
+        text("Content").size(12u32),
+        pick_list(
+            ExportContent::all(),
+            Some(modal.content),
+            Message::SendToContentChanged,
+        )
+        .width(Fill),
+    ]
+    .spacing(4);
+
+    // ── Workspace picker ─────────────────────────────────────────────────
+    let workspace_picker: Element<'_, Message> = if modal.workspaces_loading {
+        text("Loading workspaces…").size(12u32).into()
+    } else if modal.workspaces.is_empty() {
+        text("No workspaces available.").size(12u32).into()
+    } else {
+        pick_list(
+            modal.workspaces.clone(),
+            modal.selected_workspace.clone(),
+            Message::SendToWorkspaceSelected,
+        )
+        .placeholder("Choose a workspace…")
+        .width(Fill)
+        .into()
+    };
+    let workspace_field = column![text("Workspace").size(12u32), workspace_picker].spacing(4);
+
+    // ── Folder picker + Create-new toggle ────────────────────────────────
+    let folder_field: Element<'_, Message> = if modal.selected_workspace.is_none() {
+        column![
+            text("Folder").size(12u32),
+            text("Pick a workspace first.").size(11u32),
+        ]
+        .spacing(4)
+        .into()
+    } else if modal.folders_loading {
+        column![
+            text("Folder").size(12u32),
+            text("Loading folders…").size(11u32),
+        ]
+        .spacing(4)
+        .into()
+    } else if modal.creating_folder {
+        let commit_btn = if modal.new_folder_title.trim().is_empty() {
+            button("Create")
+        } else {
+            button("Create").on_press(Message::SendToCreateFolderCommit)
+        };
+        column![
+            text("New folder").size(12u32),
+            text_input("Folder title", &modal.new_folder_title)
+                .on_input(Message::SendToCreateFolderTitleChanged)
+                .width(Fill),
+            row![
+                commit_btn.style(button::primary),
+                button("Cancel")
+                    .on_press(Message::SendToCreateFolderToggle)
+                    .style(button::secondary),
+            ]
+            .spacing(vox_theme::SPACING),
+        ]
+        .spacing(4)
+        .into()
+    } else {
+        let mut choices: Vec<FolderChoice> = vec![FolderChoice::Root];
+        choices.extend(modal.folders.iter().cloned().map(FolderChoice::Existing));
+        let selected = match &modal.selected_folder {
+            Some(f) => Some(FolderChoice::Existing(f.clone())),
+            None => Some(FolderChoice::Root),
+        };
+        column![
+            text("Folder").size(12u32),
+            pick_list(choices, selected, |choice| {
+                Message::SendToFolderSelected(match choice {
+                    FolderChoice::Root => None,
+                    FolderChoice::Existing(f) => Some(f),
+                })
+            })
+            .width(Fill),
+            button("+ Create new folder")
+                .on_press(Message::SendToCreateFolderToggle)
+                .style(button::text),
+        ]
+        .spacing(4)
+        .into()
+    };
+
+    // ── Error / status line ──────────────────────────────────────────────
+    let status: Element<'_, Message> = if let Some(ref err) = modal.error {
+        text(err.clone())
+            .size(11u32)
+            .color(Color {
+                r: 0.85,
+                g: 0.25,
+                b: 0.25,
+                a: 1.0,
+            })
+            .into()
+    } else if modal.sending {
+        text("Sending…").size(11u32).into()
+    } else {
+        column![].into()
+    };
+
+    // ── Send / Cancel buttons ────────────────────────────────────────────
+    let can_send =
+        !modal.sending && modal.selected_workspace.is_some() && !modal.title.trim().is_empty();
+    let send_btn = if can_send {
+        button("Send").on_press(Message::ConfirmSendTo)
+    } else {
+        button("Send")
+    };
+
+    let buttons = row![
+        button("Cancel")
+            .on_press(Message::CloseSendToModal)
+            .style(button::secondary),
+        send_btn.style(button::primary),
+    ]
+    .spacing(vox_theme::SPACING);
+
+    column![
+        header,
+        rule::horizontal(1),
+        title_field,
+        content_field,
+        workspace_field,
+        folder_field,
+        status,
+        buttons,
     ]
     .spacing(vox_theme::SECTION_SPACING)
     .padding(vox_theme::PADDING)
@@ -1106,6 +1661,52 @@ fn view_settings(state: &VoxAppState) -> Element<'_, Message> {
         ],
     );
 
+    // ── Export (Affine) section ───────────────────────────────────────────
+    let affine_section = section_column(
+        "Export — AFFiNE",
+        column![
+            toggle_row(
+                "Enable AFFiNE export",
+                s.export.affine.enabled,
+                Message::AffineEnabledToggled,
+            ),
+            stacked_text_input(
+                "AFFiNE base URL",
+                "e.g. https://app.affine.pro or https://affine.example.com",
+                &s.export.affine.base_url,
+                Message::AffineBaseUrlChanged,
+            ),
+            column![
+                text("API token (required for AFFiNE Cloud)").size(13u32),
+                text_input(
+                    "ut_… — generate under Settings → Integrations",
+                    &s.export.affine.api_token,
+                )
+                .on_input(Message::AffineApiTokenChanged)
+                .secure(true)
+                .width(Fill),
+            ]
+            .spacing(vox_theme::SPACING / 2.0),
+            stacked_text_input(
+                "Email (self-hosted only)",
+                "Used when api_token is empty",
+                &s.export.affine.email,
+                Message::AffineEmailChanged,
+            ),
+            column![
+                text("Password (self-hosted only)").size(13u32),
+                text_input(
+                    "Stored in plaintext — chmod 600 your config",
+                    &s.export.affine.password
+                )
+                .on_input(Message::AffinePasswordChanged)
+                .secure(true)
+                .width(Fill),
+            ]
+            .spacing(vox_theme::SPACING / 2.0),
+        ],
+    );
+
     // ── About section ─────────────────────────────────────────────────────
     let about_section = section_column(
         "About",
@@ -1140,6 +1741,7 @@ fn view_settings(state: &VoxAppState) -> Element<'_, Message> {
                 summarization_section,
                 storage_section,
                 notifications_section,
+                affine_section,
                 about_section,
                 save_row,
             ]
@@ -1226,6 +1828,7 @@ fn view_session_detail(session: &Session, summarizing: bool) -> Element<'_, Mess
     // ── Action buttons ────────────────────────────────────────────────────
     let mut actions = row![
         button("Export").on_press(Message::OpenExportModal),
+        button("Send to…").on_press(Message::OpenSendToModal),
         button("Delete Session").on_press(Message::DeleteSelectedSession),
     ]
     .spacing(vox_theme::SPACING);

--- a/crates/vox-gui/src/settings.rs
+++ b/crates/vox-gui/src/settings.rs
@@ -7,8 +7,8 @@
 //! directly to the TOML serialization types.
 
 use vox_core::config::{
-    AppConfig, AudioConfig, NotificationConfig, StorageConfig, SummarizationConfig,
-    TranscriptionConfig,
+    AffineExportConfig, AppConfig, AudioConfig, ExportConfig, NotificationConfig, StorageConfig,
+    SummarizationConfig, TranscriptionConfig,
 };
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -367,6 +367,71 @@ pub struct StorageSettings {
     pub export_format: ExportFormat,
 }
 
+/// Export-target settings, mirroring [`ExportConfig`].
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ExportSettings {
+    /// `AFFiNE` export plugin settings.
+    pub affine: AffineSettings,
+}
+
+/// `AFFiNE` export plugin settings, mirroring [`AffineExportConfig`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AffineSettings {
+    /// Whether the `AFFiNE` target is enabled.
+    pub enabled: bool,
+    /// Base URL of the `AFFiNE` server (cloud or self-hosted).
+    pub base_url: String,
+    /// Personal access token (required for cloud).
+    ///
+    /// Stored in plaintext in `config.toml`; users should `chmod 600` the
+    /// config file.
+    pub api_token: String,
+    /// Login email (self-hosted only).
+    pub email: String,
+    /// Login password (self-hosted only). Plaintext — see `api_token`.
+    pub password: String,
+    /// Optional default workspace id for the Send-to picker.
+    pub default_workspace_id: String,
+    /// Optional default parent-doc id for the Send-to picker.
+    pub default_parent_id: String,
+}
+
+impl Default for AffineSettings {
+    fn default() -> Self {
+        Self::from_config(&AffineExportConfig::default())
+    }
+}
+
+impl AffineSettings {
+    /// Construct from an [`AffineExportConfig`].
+    #[must_use]
+    pub fn from_config(cfg: &AffineExportConfig) -> Self {
+        Self {
+            enabled: cfg.enabled,
+            base_url: cfg.base_url.clone(),
+            api_token: cfg.api_token.clone(),
+            email: cfg.email.clone(),
+            password: cfg.password.clone(),
+            default_workspace_id: cfg.default_workspace_id.clone(),
+            default_parent_id: cfg.default_parent_id.clone(),
+        }
+    }
+
+    /// Convert back to an [`AffineExportConfig`].
+    #[must_use]
+    pub fn to_config(&self) -> AffineExportConfig {
+        AffineExportConfig {
+            enabled: self.enabled,
+            base_url: self.base_url.clone(),
+            api_token: self.api_token.clone(),
+            email: self.email.clone(),
+            password: self.password.clone(),
+            default_workspace_id: self.default_workspace_id.clone(),
+            default_parent_id: self.default_parent_id.clone(),
+        }
+    }
+}
+
 /// Notification settings, mirroring [`NotificationConfig`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(clippy::struct_excessive_bools)]
@@ -404,6 +469,8 @@ pub struct SettingsModel {
     pub storage: StorageSettings,
     /// Notification settings.
     pub notifications: NotificationSettings,
+    /// Export-target (Affine, etc.) settings.
+    pub export: ExportSettings,
 }
 
 impl SettingsModel {
@@ -480,6 +547,9 @@ impl SettingsModel {
                 on_transcript_ready: config.notifications.on_transcript_ready,
                 on_summary_ready: config.notifications.on_summary_ready,
             },
+            export: ExportSettings {
+                affine: AffineSettings::from_config(&config.export.affine),
+            },
         }
     }
 
@@ -521,6 +591,9 @@ impl SettingsModel {
                 on_record_stop: self.notifications.on_record_stop,
                 on_transcript_ready: self.notifications.on_transcript_ready,
                 on_summary_ready: self.notifications.on_summary_ready,
+            },
+            export: ExportConfig {
+                affine: self.export.affine.to_config(),
             },
         }
     }


### PR DESCRIPTION
## Summary

- Adds a `vox-export` crate with an `ExportTarget` trait + factory, mirroring the `vox-summarize` provider pattern so future plugins (Notion, Drive, Obsidian, …) slot in as new modules.
- First plugin: AFFiNE, supporting both cloud (`app.affine.pro`, personal access token) and self-hosted (token or email/password → session cookie). Documents are created by building the full Yjs CRDT block hierarchy (`affine:page` → `affine:surface` + `affine:note` → `affine:paragraph`) and pushing it via Socket.IO `space:push-doc-update`.
- Adds a **Send to…** button in the session detail view that opens an iced modal with workspace + folder pickers, inline “Create new folder” action, and content toggles that reuse the existing `ExportContent` enum. The existing file-based Export modal is untouched.

## Architecture

| Piece | Location |
|---|---|
| Trait + DTOs | [`crates/vox-export/src/traits.rs`](crates/vox-export/src/traits.rs) |
| Factory | [`crates/vox-export/src/factory.rs`](crates/vox-export/src/factory.rs) |
| Error enum | [`crates/vox-export/src/error.rs`](crates/vox-export/src/error.rs) |
| AFFiNE target | [`crates/vox-export/src/affine/mod.rs`](crates/vox-export/src/affine/mod.rs) |
| Auth (token + password/cookie) | [`crates/vox-export/src/affine/auth.rs`](crates/vox-export/src/affine/auth.rs) |
| GraphQL metadata client | [`crates/vox-export/src/affine/graphql.rs`](crates/vox-export/src/affine/graphql.rs) |
| Yjs doc builder | [`crates/vox-export/src/affine/ydoc.rs`](crates/vox-export/src/affine/ydoc.rs) |
| Socket.IO wrapper | [`crates/vox-export/src/affine/socket.rs`](crates/vox-export/src/affine/socket.rs) |
| Send-to modal + handlers | [`crates/vox-gui/src/app.rs`](crates/vox-gui/src/app.rs) |
| Settings section | [`crates/vox-gui/src/app.rs`](crates/vox-gui/src/app.rs) + [`crates/vox-gui/src/settings.rs`](crates/vox-gui/src/settings.rs) |
| Config schema | [`crates/vox-core/src/config.rs`](crates/vox-core/src/config.rs) |

### Key design choices

- **Why Yjs CRDT over Socket.IO?** AFFiNE does not expose a REST `createDoc` endpoint. Docs are CRDT blobs synced via `space:push-doc-update`; that is the only path to create new documents. See [`ydoc.rs`](crates/vox-export/src/affine/ydoc.rs) for the block hierarchy recipe.
- **Why token-only for cloud?** `app.affine.pro` blocks programmatic email/password sign-in via Cloudflare. `AffineTarget::from_config` enforces this at construction time.
- **Plugin shape**: `ExportTarget: Send + Sync` trait with `id` / `display_name` / `list_workspaces` / `list_folders` / `create_folder` / `export`. Adding a new target is a new `crates/vox-export/src/<name>/` module and a new arm in `factory::build_targets`.
- **Markdown rendering**: the existing `vox_storage::render_export(session, \"markdown\", &options)` output is pushed as a single `affine:paragraph` block. Full markdown→blocks parsing (headings, lists, code fences) is deferred to a follow-up.

## Config

```toml
[export.affine]
enabled = true
base_url = \"https://app.affine.pro\"   # or https://affine.example.com
api_token = \"ut_…\"                      # required for cloud
email = \"\"                              # self-hosted fallback
password = \"\"                           # self-hosted fallback
default_workspace_id = \"\"
default_parent_id = \"\"
```

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p vox-core -p vox-export -p vox-gui --features vox-gui/ui` — 73 tests pass (14 core + 29 export + 30 gui)
- [x] `cargo clippy -p vox-core -p vox-export --all-targets -- -D warnings` — clean
- [x] `cargo build --workspace --all-targets` — clean
- [ ] Manual QA against a real self-hosted AFFiNE: enable in settings → open session → Send to… → pick workspace → pick folder (or Create new) → Send → verify doc appears in AFFiNE sidebar with content rendered
- [ ] Manual QA against AFFiNE Cloud with a personal access token

Pre-existing clippy pedantic warnings in `vox-summarize`, `vox-diarize`, `vox-gui/search.rs`, and older sections of `vox-gui/src/app.rs` are unchanged on this branch; they should be cleaned up in a separate PR.

## Out of scope for this change

- Markdown → native AFFiNE block rendering (headings / lists / code fences) — currently a single paragraph block.
- OS keyring integration for credentials — keeps the existing plaintext-TOML pattern already used by `summarization.api_key`.
- Additional plugins (Notion, Drive, Obsidian). The trait + factory are ready for them.
- Auto-export on session completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)