### PR TITLE
fix(daemon): make Stop Recording non-blocking

### DIFF
--- a/vox-daemon/src/daemon.rs
+++ b/vox-daemon/src/daemon.rs
@@ -2,24 +2,42 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
+use uuid::Uuid;
 use vox_core::config::AppConfig;
 use vox_notify::Notifier;
 use vox_tray::{DaemonStatus, Tray, TrayEvent};
 
-use crate::recording;
+use crate::recording::{self, CaptureOutput};
 
-/// State of a recording task running in the background.
-struct RecordingTask {
-    /// Handle to the spawned tokio task.
-    handle: tokio::task::JoinHandle<Result<()>>,
-    /// Flag to signal the recording to stop.
+/// State of a capture (recording) task running in the background.
+///
+/// Only the audio capture runs while this task is active. Transcription and
+/// summarization run in a separate [`PendingProcessing`] task spawned after
+/// capture completes, so the tray can return to `Idle` immediately.
+struct CaptureTask {
+    /// Handle to the spawned capture task.
+    handle: tokio::task::JoinHandle<Result<CaptureOutput>>,
+    /// Flag to signal the capture to stop.
     stop_flag: Arc<AtomicBool>,
-    /// When the recording started.
+    /// When capture started.
     started_at: Instant,
 }
+
+/// A background processing job (transcription + save + summarization) for a
+/// session whose capture phase has already finished.
+struct PendingProcessing {
+    /// UUID of the session being processed.
+    session_id: Uuid,
+    /// Handle to the spawned processing task.
+    handle: tokio::task::JoinHandle<Result<recording::ProcessingOutcome>>,
+}
+
+/// Maximum time the daemon waits for in-flight background processing to
+/// finish during shutdown before abandoning it.
+const SHUTDOWN_PROCESSING_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Run the daemon process.
 ///
@@ -49,8 +67,10 @@ pub async fn run(config: AppConfig) -> Result<()> {
 
     tracing::info!("daemon ready — listening for tray events (press Ctrl+C to stop)");
 
-    // Active recording task, if any.
-    let mut active_recording: Option<RecordingTask> = None;
+    // Active capture task, if any.
+    let mut active_capture: Option<CaptureTask> = None;
+    // Background processing jobs for previously captured sessions.
+    let mut pending_processing: Vec<PendingProcessing> = Vec::new();
 
     // Poll tray events alongside Ctrl+C shutdown
     let shutdown = tokio::signal::ctrl_c();
@@ -60,26 +80,51 @@ pub async fn run(config: AppConfig) -> Result<()> {
         tokio::select! {
             _ = &mut shutdown => {
                 tracing::info!("shutdown signal received, stopping daemon");
-                // Stop any active recording before exiting.
-                if let Some(task) = active_recording.take() {
+                // Stop any active capture before exiting.
+                if let Some(task) = active_capture.take() {
                     task.stop_flag.store(true, Ordering::Relaxed);
-                    match task.handle.await {
-                        Ok(Ok(())) => tracing::info!("recording stopped cleanly on shutdown"),
-                        Ok(Err(e)) => tracing::warn!("recording ended with error on shutdown: {e}"),
-                        Err(e) => tracing::error!("recording task panicked on shutdown: {e}"),
-                    }
+                    let duration = task.started_at.elapsed();
+                    let capture_result = task.handle.await;
+                    finish_capture(
+                        capture_result,
+                        duration,
+                        &tray,
+                        &*notifier,
+                        &mut pending_processing,
+                    )?;
                 }
+                drain_pending(pending_processing, &*notifier, SHUTDOWN_PROCESSING_TIMEOUT).await;
                 break;
             }
             () = tokio::task::yield_now() => {
                 if let Some(event) = tray.try_recv_event() {
-                    match handle_tray_event(event, &config, &tray, &*notifier, &mut active_recording).await {
+                    match handle_tray_event(
+                        event,
+                        &config,
+                        &tray,
+                        &*notifier,
+                        &mut active_capture,
+                        &mut pending_processing,
+                    ).await {
                         Ok(should_quit) if should_quit => {
-                            // Stop any active recording before quitting.
-                            if let Some(task) = active_recording.take() {
+                            // Stop any active capture before quitting.
+                            if let Some(task) = active_capture.take() {
                                 task.stop_flag.store(true, Ordering::Relaxed);
-                                let _ = task.handle.await;
+                                let duration = task.started_at.elapsed();
+                                let capture_result = task.handle.await;
+                                finish_capture(
+                                    capture_result,
+                                    duration,
+                                    &tray,
+                                    &*notifier,
+                                    &mut pending_processing,
+                                )?;
                             }
+                            drain_pending(
+                                pending_processing,
+                                &*notifier,
+                                SHUTDOWN_PROCESSING_TIMEOUT,
+                            ).await;
                             break;
                         }
                         Ok(_) => {}
@@ -87,31 +132,28 @@ pub async fn run(config: AppConfig) -> Result<()> {
                     }
                 }
 
-                // Check if the active recording has finished on its own.
-                if let Some(ref task) = active_recording {
+                // Check if the active capture has finished on its own (e.g.,
+                // capture loop's own Ctrl+C handler fired).
+                if let Some(ref task) = active_capture {
                     if task.handle.is_finished() {
-                        let task = active_recording.take().expect("just checked Some");
+                        let task = active_capture.take().expect("just checked Some");
                         let duration = task.started_at.elapsed();
-                        match task.handle.await {
-                            Ok(Ok(())) => {
-                                tracing::info!("recording completed successfully");
-                                if let Err(e) = notifier.recording_stopped(duration) {
-                                    tracing::warn!("notification failed: {e}");
-                                }
-                            }
-                            Ok(Err(e)) => {
-                                tracing::error!("recording failed: {e}");
-                            }
-                            Err(e) => {
-                                tracing::error!("recording task panicked: {e}");
-                            }
-                        }
-                        tray.set_status(DaemonStatus::Idle)
-                            .map_err(|e| anyhow::anyhow!("{e}"))?;
+                        let capture_result = task.handle.await;
+                        finish_capture(
+                            capture_result,
+                            duration,
+                            &tray,
+                            &*notifier,
+                            &mut pending_processing,
+                        )?;
                     }
                 }
 
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                // Check for completed background processing jobs and fire
+                // transcript_ready / summary_ready notifications.
+                poll_pending_processing(&mut pending_processing, &*notifier).await;
+
+                tokio::time::sleep(Duration::from_millis(50)).await;
             }
         }
     }
@@ -127,11 +169,12 @@ async fn handle_tray_event(
     config: &AppConfig,
     tray: &impl Tray,
     notifier: &dyn Notifier,
-    active_recording: &mut Option<RecordingTask>,
+    active_capture: &mut Option<CaptureTask>,
+    pending_processing: &mut Vec<PendingProcessing>,
 ) -> Result<bool> {
     match event {
         TrayEvent::StartRecording => {
-            if active_recording.is_some() {
+            if active_capture.is_some() {
                 tracing::warn!("recording already in progress, ignoring start request");
                 return Ok(false);
             }
@@ -154,40 +197,27 @@ async fn handle_tray_event(
             let started_at = Instant::now();
 
             let handle = tokio::spawn(async move {
-                recording::record_session(config_clone, None, None, Some(flag_clone)).await
+                recording::capture_session(config_clone, None, None, Some(flag_clone)).await
             });
 
-            *active_recording = Some(RecordingTask {
+            *active_capture = Some(CaptureTask {
                 handle,
                 stop_flag,
                 started_at,
             });
         }
         TrayEvent::StopRecording => {
-            if let Some(task) = active_recording.take() {
+            if let Some(task) = active_capture.take() {
                 tracing::info!("stop recording requested via tray");
                 task.stop_flag.store(true, Ordering::Relaxed);
                 let duration = task.started_at.elapsed();
-
-                match task.handle.await {
-                    Ok(Ok(())) => {
-                        tracing::info!("recording stopped successfully");
-                        if let Err(e) = notifier.recording_stopped(duration) {
-                            tracing::warn!("notification failed: {e}");
-                        }
-                    }
-                    Ok(Err(e)) => {
-                        tracing::error!("recording ended with error: {e}");
-                    }
-                    Err(e) => {
-                        tracing::error!("recording task panicked: {e}");
-                    }
-                }
+                let capture_result = task.handle.await;
+                finish_capture(capture_result, duration, tray, notifier, pending_processing)?;
             } else {
                 tracing::info!("stop recording requested but no recording in progress");
+                tray.set_status(DaemonStatus::Idle)
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
             }
-            tray.set_status(DaemonStatus::Idle)
-                .map_err(|e| anyhow::anyhow!("{e}"))?;
         }
         TrayEvent::PauseRecording => {
             tracing::info!("pause recording requested via tray (not yet implemented)");
@@ -227,6 +257,125 @@ async fn handle_tray_event(
     Ok(false)
 }
 
+/// Finalise the capture phase: flip the tray to Idle, fire the
+/// `recording_stopped` notification, and if any audio was captured spawn a
+/// background processing task for transcription + summarization.
+///
+/// The tray is updated **before** processing is spawned so the user can
+/// immediately start a new recording while the prior session is still being
+/// transcribed.
+fn finish_capture(
+    capture_result: std::result::Result<Result<CaptureOutput>, tokio::task::JoinError>,
+    duration: Duration,
+    tray: &impl Tray,
+    notifier: &dyn Notifier,
+    pending_processing: &mut Vec<PendingProcessing>,
+) -> Result<()> {
+    // Flip the tray back to Idle first so the user can start a new recording
+    // immediately. The notification + spawn happen on the heels of this.
+    tray.set_status(DaemonStatus::Idle)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    match capture_result {
+        Ok(Ok(capture)) => {
+            tracing::info!("capture stopped successfully");
+            if let Err(e) = notifier.recording_stopped(duration) {
+                tracing::warn!("notification failed: {e}");
+            }
+            if capture.is_empty() {
+                tracing::warn!("no audio captured, skipping transcription");
+                return Ok(());
+            }
+            let session_id = capture.session.id;
+            let handle = tokio::spawn(async move { recording::process_session(capture).await });
+            pending_processing.push(PendingProcessing { session_id, handle });
+            tracing::info!(
+                "processing spawned in background for session {session_id} \
+                 ({} job(s) pending)",
+                pending_processing.len()
+            );
+        }
+        Ok(Err(e)) => {
+            tracing::error!("capture ended with error: {e}");
+            if let Err(e) = notifier.recording_stopped(duration) {
+                tracing::warn!("notification failed: {e}");
+            }
+        }
+        Err(e) => {
+            tracing::error!("capture task panicked: {e}");
+        }
+    }
+    Ok(())
+}
+
+/// Sweep the pending-processing list for finished jobs and fire their
+/// completion notifications.
+async fn poll_pending_processing(pending: &mut Vec<PendingProcessing>, notifier: &dyn Notifier) {
+    let mut i = 0;
+    while i < pending.len() {
+        if pending[i].handle.is_finished() {
+            let job = pending.swap_remove(i);
+            handle_processing_result(job, notifier).await;
+        } else {
+            i += 1;
+        }
+    }
+}
+
+/// Await a single completed processing job and fire the appropriate
+/// notifications.
+async fn handle_processing_result(job: PendingProcessing, notifier: &dyn Notifier) {
+    let PendingProcessing { session_id, handle } = job;
+    match handle.await {
+        Ok(Ok(outcome)) => {
+            tracing::info!(
+                "background processing complete for session {}",
+                outcome.session_id
+            );
+            if let Err(e) = notifier.transcript_ready(outcome.session_id) {
+                tracing::warn!("transcript notification failed: {e}");
+            }
+            if outcome.summary_generated {
+                if let Err(e) = notifier.summary_ready(outcome.session_id) {
+                    tracing::warn!("summary notification failed: {e}");
+                }
+            }
+        }
+        Ok(Err(e)) => {
+            tracing::error!("background processing failed for session {session_id}: {e}");
+        }
+        Err(e) => {
+            tracing::error!("background processing task panicked for session {session_id}: {e}");
+        }
+    }
+}
+
+/// Drain in-flight processing jobs during shutdown, bounded by a total
+/// timeout. Jobs that don't finish in time are abandoned with a warning.
+async fn drain_pending(
+    pending: Vec<PendingProcessing>,
+    notifier: &dyn Notifier,
+    timeout: Duration,
+) {
+    if pending.is_empty() {
+        return;
+    }
+    tracing::info!(
+        "waiting up to {:?} for {} background processing job(s) before exit",
+        timeout,
+        pending.len()
+    );
+    let drained = tokio::time::timeout(timeout, async {
+        for job in pending {
+            handle_processing_result(job, notifier).await;
+        }
+    })
+    .await;
+    if drained.is_err() {
+        tracing::warn!("shutdown timeout reached; abandoning remaining in-flight processing jobs");
+    }
+}
+
 /// Spawn the GUI as a child process so iced/winit can use the main thread.
 ///
 /// `page` should be `"settings"` or `"browser"`.
@@ -245,5 +394,119 @@ fn launch_gui(page: &str) {
     {
         Ok(child) => tracing::info!(pid = child.id(), "GUI process spawned"),
         Err(e) => tracing::error!("failed to spawn GUI process: {e}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::time::Duration;
+
+    use tempfile::TempDir;
+    use vox_capture::types::{AudioChunk, StreamRole};
+    use vox_core::session::{AudioRole, AudioSourceInfo, ConfigSnapshot, Session};
+    use vox_notify::StubNotifier;
+    use vox_tray::MockTray;
+
+    fn test_config_with_tempdir(dir: &TempDir) -> AppConfig {
+        let mut cfg = AppConfig::default();
+        cfg.storage.data_dir = dir.path().to_string_lossy().into_owned();
+        cfg.summarization.auto_summarize = false;
+        cfg
+    }
+
+    fn dummy_session(cfg: &AppConfig) -> Session {
+        let sources = vec![AudioSourceInfo {
+            name: "mic".to_owned(),
+            pipewire_node_id: 0,
+            role: AudioRole::Microphone,
+        }];
+        let snap = ConfigSnapshot {
+            model: cfg.transcription.model.clone(),
+            language: cfg.transcription.language.clone(),
+            gpu_backend: cfg.transcription.gpu_backend.clone(),
+            diarization_mode: cfg.transcription.diarization_mode.clone(),
+            decoding_strategy: cfg.transcription.decoding_strategy.clone(),
+            initial_prompt: cfg.transcription.initial_prompt.clone(),
+        };
+        Session::new(sources, snap)
+    }
+
+    /// Core invariant of the fix: `finish_capture` must hand the heavy work
+    /// to a background task and return immediately, so the tray flips to
+    /// `Idle` and the `recording_stopped` notification fires without
+    /// waiting for transcription / summarization.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn finish_capture_returns_without_awaiting_processing() {
+        let tmp = TempDir::new().expect("tempdir");
+        let cfg = test_config_with_tempdir(&tmp);
+        let session = dummy_session(&cfg);
+
+        let mic_chunk = AudioChunk::new(
+            vec![0.1_f32; 16_000],
+            Duration::ZERO,
+            StreamRole::Microphone,
+        );
+        let capture = CaptureOutput {
+            config: cfg,
+            session,
+            mic_chunks: vec![mic_chunk],
+            app_chunks: Vec::new(),
+        };
+
+        let tray = MockTray::new();
+        let notifier = StubNotifier::new();
+        let mut pending: Vec<PendingProcessing> = Vec::new();
+
+        let before = std::time::Instant::now();
+        finish_capture(
+            Ok(Ok(capture)),
+            Duration::from_secs(1),
+            &tray,
+            &notifier,
+            &mut pending,
+        )
+        .expect("finish_capture should succeed");
+        let elapsed = before.elapsed();
+
+        // Tray flipped to Idle before we returned.
+        assert_eq!(tray.last_status(), Some(DaemonStatus::Idle));
+        // Exactly one background processing job was queued.
+        assert_eq!(pending.len(), 1);
+        // finish_capture itself is synchronous: it must not block on the
+        // spawned task. Allow a generous bound to keep CI happy.
+        assert!(
+            elapsed < Duration::from_millis(250),
+            "finish_capture took {elapsed:?}; it must not await processing"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn finish_capture_empty_capture_does_not_spawn_processing() {
+        let tmp = TempDir::new().expect("tempdir");
+        let cfg = test_config_with_tempdir(&tmp);
+        let capture = CaptureOutput {
+            session: dummy_session(&cfg),
+            config: cfg,
+            mic_chunks: Vec::new(),
+            app_chunks: Vec::new(),
+        };
+
+        let tray = MockTray::new();
+        let notifier = StubNotifier::new();
+        let mut pending: Vec<PendingProcessing> = Vec::new();
+
+        finish_capture(
+            Ok(Ok(capture)),
+            Duration::from_secs(1),
+            &tray,
+            &notifier,
+            &mut pending,
+        )
+        .expect("finish_capture should succeed");
+
+        assert_eq!(tray.last_status(), Some(DaemonStatus::Idle));
+        assert!(pending.is_empty());
     }
 }

--- a/vox-daemon/src/recording.rs
+++ b/vox-daemon/src/recording.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use uuid::Uuid;
 use vox_capture::{AudioChunk, AudioSource, StreamRole};
 use vox_core::config::AppConfig;
 use vox_core::session::{
@@ -13,19 +14,82 @@ use vox_core::session::{
 use vox_storage::{JsonFileStore, SessionStore};
 use vox_transcribe::{AudioSourceRole, Transcriber, TranscriptionRequest};
 
-/// Run a recording session.
+/// Captured audio plus the in-progress [`Session`] skeleton, ready to be
+/// handed to [`process_session`] for transcription and storage.
 ///
-/// Captures audio from `PipeWire` (or a mock source), transcribes it with Whisper
-/// (or a stub transcriber), and saves the resulting session to disk.
+/// Splitting recording into a capture phase and a processing phase lets the
+/// daemon hand the heavy work (Whisper inference, summarization) off to a
+/// background task while immediately freeing the tray to start a new
+/// recording.
+pub struct CaptureOutput {
+    /// Config snapshot taken at the start of the recording. Carried through
+    /// so the processing phase uses the same settings that were active when
+    /// the user pressed Start, even if the config file changes mid-call.
+    pub config: AppConfig,
+    /// Session skeleton with a freshly minted UUID and config snapshot.
+    pub session: Session,
+    /// Raw microphone chunks captured during the session.
+    pub mic_chunks: Vec<AudioChunk>,
+    /// Raw application-audio chunks captured during the session.
+    pub app_chunks: Vec<AudioChunk>,
+}
+
+impl CaptureOutput {
+    /// Returns `true` when no audio samples were captured from either source.
+    /// Used by callers to skip the processing phase entirely.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        let mic: usize = self.mic_chunks.iter().map(|c| c.samples.len()).sum();
+        let app: usize = self.app_chunks.iter().map(|c| c.samples.len()).sum();
+        mic == 0 && app == 0
+    }
+}
+
+/// Result of running the processing phase on a [`CaptureOutput`].
 ///
-/// The `stop_flag` allows external callers (e.g., the daemon) to signal the
-/// recording to stop. When `None`, the recording runs until Ctrl+C.
+/// Reports which notifications the daemon should fire.
+#[derive(Debug, Clone, Copy)]
+pub struct ProcessingOutcome {
+    /// UUID of the saved session — used to key the `transcript_ready` and
+    /// `summary_ready` notifications.
+    pub session_id: Uuid,
+    /// `true` when auto-summarization ran and successfully produced a summary.
+    pub summary_generated: bool,
+}
+
+/// Run capture + processing as a single sequential operation.
+///
+/// Convenience wrapper for callers (e.g., the CLI `record` subcommand) that
+/// don't need the capture / processing split. The daemon does **not** use
+/// this — it invokes [`capture_session`] and [`process_session`] separately
+/// so it can return control to the user as soon as capture stops.
 pub async fn record_session(
     config: AppConfig,
     mic_override: Option<String>,
     app_override: Option<String>,
     stop_flag: Option<Arc<AtomicBool>>,
 ) -> Result<()> {
+    let capture = capture_session(config, mic_override, app_override, stop_flag).await?;
+    if capture.is_empty() {
+        tracing::warn!("no audio captured, skipping transcription");
+        return Ok(());
+    }
+    process_session(capture).await?;
+    Ok(())
+}
+
+/// Capture phase — record audio from `PipeWire` (or a mock source) until
+/// stopped, then return the raw chunks plus a [`Session`] skeleton.
+///
+/// This is the only blocking phase the daemon awaits before clearing the
+/// "recording" tray state. The `PipeWire` stop handshake is bounded to a few
+/// seconds, so this completes promptly after `stop_flag` is set.
+pub async fn capture_session(
+    config: AppConfig,
+    mic_override: Option<String>,
+    app_override: Option<String>,
+    stop_flag: Option<Arc<AtomicBool>>,
+) -> Result<CaptureOutput> {
     let (mic_chunks, app_chunks) =
         capture_audio(&config, mic_override, app_override, stop_flag).await?;
 
@@ -37,12 +101,28 @@ pub async fn record_session(
         app_sample_count
     );
 
-    if mic_sample_count == 0 && app_sample_count == 0 {
-        tracing::warn!("no audio captured, skipping transcription");
-        return Ok(());
-    }
+    let session = build_session(&config, mic_sample_count, app_sample_count);
 
-    let mut session = build_session(&config, mic_sample_count, app_sample_count);
+    Ok(CaptureOutput {
+        config,
+        session,
+        mic_chunks,
+        app_chunks,
+    })
+}
+
+/// Processing phase — transcribe captured audio, save the session, and run
+/// auto-summarization if enabled.
+///
+/// Intended to be run as a detached background task: the daemon does **not**
+/// await this before allowing a new recording to start.
+pub async fn process_session(capture: CaptureOutput) -> Result<ProcessingOutcome> {
+    let CaptureOutput {
+        config,
+        mut session,
+        mic_chunks,
+        app_chunks,
+    } = capture;
 
     let merged = transcribe_audio(&config, &mut session, &mic_chunks, &app_chunks)?;
 
@@ -67,6 +147,7 @@ pub async fn record_session(
     tracing::info!("session saved: {}", session.id);
 
     // Auto-summarize if configured
+    let mut summary_generated = false;
     if config.summarization.auto_summarize && !session.transcript.is_empty() {
         match auto_summarize(&config, &mut session).await {
             Ok(()) => {
@@ -74,6 +155,7 @@ pub async fn record_session(
                     .save(&session)
                     .context("failed to save session after summarization")?;
                 tracing::info!("auto-summarization complete for session {}", session.id);
+                summary_generated = true;
             }
             Err(e) => {
                 tracing::warn!("auto-summarization failed (session saved without summary): {e}");
@@ -81,7 +163,10 @@ pub async fn record_session(
         }
     }
 
-    Ok(())
+    Ok(ProcessingOutcome {
+        session_id: session.id,
+        summary_generated,
+    })
 }
 
 /// Run auto-summarization on the session transcript.


### PR DESCRIPTION
## Summary

When the user clicks **Stop Recording** in the tray today, the icon stays red and a new recording cannot be started until both Whisper transcription *and* LLM summarization complete — often 30 s to several minutes. This change makes the stop action effectively instant.

After this PR, on Stop:

- The tray flips back to `Idle` (green) as soon as the bounded PipeWire stop handshake completes (sub-second in practice).
- The `recording_stopped` desktop notification fires immediately.
- Transcription, session save, and auto-summarization continue in a detached background task.
- A new recording can be started immediately, even while the previous session is still being processed. Multiple concurrent background jobs are supported.

When background processing finishes, `transcript_ready` and `summary_ready` notifications fire (both methods already existed in the `Notifier` trait but were previously unused). On daemon shutdown the daemon waits up to 60 s for in-flight jobs before abandoning them.

### Implementation

- [vox-daemon/src/recording.rs](vox-daemon/src/recording.rs) — split `record_session` into `capture_session` (capture + build `Session` skeleton) and `process_session` (transcribe + save + summarize). The original `record_session` is kept as a thin wrapper for the CLI `record` subcommand.
- [vox-daemon/src/daemon.rs](vox-daemon/src/daemon.rs) — `RecordingTask` becomes `CaptureTask` (returns a `CaptureOutput`). New `PendingProcessing` struct + `Vec<PendingProcessing>` on the run loop. A new `finish_capture` helper handles the pivot: set tray Idle, fire notification, spawn processing. The main loop polls the pending list each tick. Shutdown drains pending jobs with `tokio::time::timeout`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p vox-daemon --all-targets -- -D warnings`
- [x] `cargo test -p vox-daemon` — includes new `finish_capture_returns_without_awaiting_processing` test which proves the synchronous pivot (queues a processing job and returns in <250 ms even though processing is still running), and `finish_capture_empty_capture_does_not_spawn_processing` for the empty-audio edge case.
- [ ] Manual end-to-end on Linux desktop with PipeWire:
  - Start daemon (`cargo run --features "pw,gtk,whisper,ui" -- start`).
  - Click Start, speak ~10 s, click Stop. Confirm tray turns green and the notification appears within ~1 s.
  - Immediately click Start Recording and confirm it transitions to red and begins a new capture.
  - A few minutes later, confirm `Transcript ready` and `Summary ready` notifications fire for the *first* session, with the second still running.
  - Both sessions visible in the transcripts browser with correct content.
- [ ] Edge cases:
  - Stop → quit before background processing finishes — confirm log shows the drain timeout and exit is clean.
  - Stop → Stop again immediately — second click is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)