### PR TITLE
fix(transcribe): prevent Whisper decode-repetition loops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5471,6 +5471,7 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "uuid",
  "vox-capture",

--- a/crates/vox-core/src/config.rs
+++ b/crates/vox-core/src/config.rs
@@ -161,6 +161,20 @@ pub struct TranscriptionConfig {
     #[serde(default)]
     pub initial_prompt: String,
 
+    /// Condition each internal decode window on previously generated text.
+    ///
+    /// This is Whisper's default behaviour. Disabling it (the default here)
+    /// prevents runaway repetition loops where a hallucinated phrase over a
+    /// silent stretch primes the next window and self-perpetuates.
+    #[serde(default)]
+    pub condition_on_previous_text: bool,
+
+    /// Runs of this many or more consecutive identical segments are collapsed
+    /// to a single segment as a decode-loop hallucination guard. `0` or `1`
+    /// disables collapsing.
+    #[serde(default = "default_repeat_collapse_threshold")]
+    pub repeat_collapse_threshold: usize,
+
     /// Initial decoding temperature. `0.0` is most confident.
     #[serde(default)]
     pub temperature: f32,
@@ -224,6 +238,8 @@ impl Default for TranscriptionConfig {
             beam_size: 5,
             best_of: 5,
             initial_prompt: String::new(),
+            condition_on_previous_text: false,
+            repeat_collapse_threshold: 3,
             temperature: 0.0,
             temperature_inc: 0.2,
             entropy_thold: 2.4,
@@ -463,6 +479,10 @@ fn default_best_of() -> i32 {
 
 fn default_temperature_inc() -> f32 {
     0.2
+}
+
+fn default_repeat_collapse_threshold() -> usize {
+    3
 }
 
 fn default_entropy_thold() -> f32 {

--- a/crates/vox-core/src/session.rs
+++ b/crates/vox-core/src/session.rs
@@ -97,6 +97,9 @@ pub struct ConfigSnapshot {
     /// Initial prompt used to condition the decoder.
     #[serde(default)]
     pub initial_prompt: String,
+    /// Whether decode windows were conditioned on previously generated text.
+    #[serde(default)]
+    pub condition_on_previous_text: bool,
 }
 
 fn default_diarization_mode() -> String {
@@ -185,6 +188,7 @@ mod tests {
             diarization_mode: "none".to_owned(),
             decoding_strategy: "beam_search".to_owned(),
             initial_prompt: String::new(),
+            condition_on_previous_text: false,
         };
         let session = Session::new(sources, config);
         assert_eq!(session.duration_seconds, 0);
@@ -214,6 +218,7 @@ mod tests {
                 diarization_mode: "none".to_owned(),
                 decoding_strategy: "beam_search".to_owned(),
                 initial_prompt: String::new(),
+                condition_on_previous_text: false,
             },
         );
 

--- a/crates/vox-gui/Cargo.toml
+++ b/crates/vox-gui/Cargo.toml
@@ -17,6 +17,7 @@ thiserror = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 rfd = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }
 
 [dependencies.iced]
 version = "0.14"
@@ -25,7 +26,7 @@ features = ["tokio"]
 
 [features]
 default = []
-ui = ["dep:iced", "dep:rfd"]
+ui = ["dep:iced", "dep:rfd", "dep:tokio"]
 pw = ["vox-capture/pw"]
 
 [dev-dependencies]

--- a/crates/vox-gui/src/app.rs
+++ b/crates/vox-gui/src/app.rs
@@ -225,6 +225,12 @@ pub enum Message {
     SummaryGenerated(Result<Box<Summary>, String>),
     /// The summary was persisted to disk after generation (carries success flag).
     SummarySaved(bool),
+
+    // ── Browser: reprocess audio ─────────────────────────────────────────
+    /// The user requested re-running transcription on the session's retained audio.
+    ReprocessAudio,
+    /// Audio reprocessing finished (carries the reloaded session or an error message).
+    AudioReprocessed(Result<Box<Session>, String>),
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -292,6 +298,9 @@ pub struct VoxAppState {
     /// Whether a summary generation is currently in progress.
     pub summarizing: bool,
 
+    /// Whether an audio reprocessing (re-transcription) is currently in progress.
+    pub reprocessing: bool,
+
     /// When `Some`, the export modal is open.
     pub export_modal: Option<ExportModalState>,
 }
@@ -358,6 +367,7 @@ impl VoxAppState {
             selected_session,
             browser_status: None,
             summarizing: false,
+            reprocessing: false,
             export_modal: None,
         }
     }
@@ -841,7 +851,98 @@ pub fn update(state: &mut VoxAppState, message: Message) -> Task<Message> {
             }
             Task::none()
         }
+
+        // ── Browser: reprocess audio ─────────────────────────────────────
+        Message::ReprocessAudio => {
+            let Some(ref session) = state.selected_session else {
+                return Task::none();
+            };
+            // Only reprocessable when retained audio still exists on disk.
+            let Some(audio_path) = session.audio_file_path.as_deref().filter(|p| !p.is_empty())
+            else {
+                state.browser_status = Some("No retained audio for this session.".to_owned());
+                return Task::none();
+            };
+            if !std::path::Path::new(audio_path).exists() {
+                state.browser_status = Some("Retained audio file not found on disk.".to_owned());
+                return Task::none();
+            }
+            state.reprocessing = true;
+            state.browser_status = Some("Reprocessing audio…".to_owned());
+            let session_id = session.id;
+            let data_dir = state.settings.storage.data_dir.clone();
+            Task::perform(
+                reprocess_via_subprocess(session_id, data_dir),
+                Message::AudioReprocessed,
+            )
+        }
+        Message::AudioReprocessed(result) => {
+            state.reprocessing = false;
+            match result {
+                Ok(session) => {
+                    let session = *session;
+                    info!(
+                        "audio reprocessed: transcript now {} segments",
+                        session.transcript.len()
+                    );
+                    // Refresh the list entry preview to match the new transcript.
+                    if let Some(entry) = state.session_list.iter_mut().find(|e| e.id == session.id)
+                    {
+                        *entry = SessionListEntry::from_session(&session);
+                    }
+                    state.browser_status = Some(format!(
+                        "Reprocessed: {} segments.",
+                        session.transcript.len()
+                    ));
+                    state.selected_session = Some(session);
+                    Task::none()
+                }
+                Err(e) => {
+                    error!("audio reprocess failed: {e}");
+                    state.browser_status = Some(format!("Reprocessing failed: {e}"));
+                    Task::none()
+                }
+            }
+        }
     }
+}
+
+/// Re-run transcription on a session's retained audio by invoking this same
+/// binary's `reprocess` subcommand, then reload the updated session from disk.
+///
+/// Transcription requires the `whisper` feature and the Whisper model, which
+/// live in the daemon binary — not in `vox-gui`. Rather than pull that
+/// dependency (and the GPU toolchain) into the GUI crate, we shell out to the
+/// already-built `reprocess` subcommand of the running executable, which loads
+/// the current config and overwrites the session transcript in place.
+async fn reprocess_via_subprocess(
+    session_id: Uuid,
+    data_dir: String,
+) -> Result<Box<Session>, String> {
+    let exe = std::env::current_exe().map_err(|e| format!("cannot locate executable: {e}"))?;
+    let output = tokio::process::Command::new(exe)
+        .arg("reprocess")
+        .arg(session_id.to_string())
+        .output()
+        .await
+        .map_err(|e| format!("failed to launch reprocess: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Surface the most useful line (the error chain's first line) to the UI.
+        let detail = stderr
+            .lines()
+            .rev()
+            .find(|l| !l.trim().is_empty())
+            .unwrap_or("reprocess subcommand failed")
+            .trim()
+            .to_owned();
+        return Err(detail);
+    }
+
+    let store = JsonFileStore::new(&data_dir).map_err(|e| e.to_string())?;
+    let session = store.load(session_id).map_err(|e| e.to_string())?;
+    Ok(Box::new(session))
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -1310,7 +1411,7 @@ fn view_browser(state: &VoxAppState) -> Element<'_, Message> {
 
     // ── Detail panel ──────────────────────────────────────────────────────
     let detail: Element<'_, Message> = if let Some(ref session) = state.selected_session {
-        view_session_detail(session, state.summarizing)
+        view_session_detail(session, state.summarizing, state.reprocessing)
     } else {
         container(text("Select a session to view its transcript."))
             .center_x(Fill)
@@ -1336,7 +1437,11 @@ fn view_browser(state: &VoxAppState) -> Element<'_, Message> {
     .into()
 }
 
-fn view_session_detail(session: &Session, summarizing: bool) -> Element<'_, Message> {
+fn view_session_detail(
+    session: &Session,
+    summarizing: bool,
+    reprocessing: bool,
+) -> Element<'_, Message> {
     // ── Action buttons ────────────────────────────────────────────────────
     let mut actions = row![
         button("Export").on_press(Message::OpenExportModal),
@@ -1359,6 +1464,23 @@ fn view_session_detail(session: &Session, summarizing: bool) -> Element<'_, Mess
             button("Regenerate Summary").on_press(Message::RegenerateSummary)
         };
         actions = actions.push(summarize_btn);
+    }
+
+    // Show "Reprocess Audio" only when this session has retained audio still on
+    // disk — re-runs transcription with the current settings, overwriting the
+    // transcript (useful for testing transcription changes without re-recording).
+    let has_retained_audio = session
+        .audio_file_path
+        .as_deref()
+        .filter(|p| !p.is_empty())
+        .is_some_and(|p| std::path::Path::new(p).exists());
+    if has_retained_audio {
+        let reprocess_btn = if reprocessing {
+            button("Reprocessing…")
+        } else {
+            button("Reprocess Audio").on_press(Message::ReprocessAudio)
+        };
+        actions = actions.push(reprocess_btn);
     }
 
     // ── Summary section (if present) ─────────────────────────────────────

--- a/crates/vox-gui/src/browser.rs
+++ b/crates/vox-gui/src/browser.rs
@@ -134,6 +134,7 @@ mod tests {
                 diarization_mode: "none".to_owned(),
                 decoding_strategy: String::new(),
                 initial_prompt: String::new(),
+                condition_on_previous_text: false,
             },
         )
     }

--- a/crates/vox-gui/src/search.rs
+++ b/crates/vox-gui/src/search.rs
@@ -100,6 +100,7 @@ mod tests {
                 diarization_mode: "none".to_owned(),
                 decoding_strategy: String::new(),
                 initial_prompt: String::new(),
+                condition_on_previous_text: false,
             },
         );
         s.transcript = segments

--- a/crates/vox-storage/src/json_export.rs
+++ b/crates/vox-storage/src/json_export.rs
@@ -72,6 +72,7 @@ mod tests {
                 diarization_mode: "none".to_owned(),
                 decoding_strategy: String::new(),
                 initial_prompt: String::new(),
+                condition_on_previous_text: false,
             },
         )
     }

--- a/crates/vox-storage/src/markdown.rs
+++ b/crates/vox-storage/src/markdown.rs
@@ -242,6 +242,7 @@ mod tests {
                 diarization_mode: "none".to_owned(),
                 decoding_strategy: String::new(),
                 initial_prompt: String::new(),
+                condition_on_previous_text: false,
             },
         )
     }

--- a/crates/vox-storage/src/store.rs
+++ b/crates/vox-storage/src/store.rs
@@ -204,6 +204,7 @@ mod tests {
                 diarization_mode: "none".to_owned(),
                 decoding_strategy: String::new(),
                 initial_prompt: String::new(),
+                condition_on_previous_text: false,
             },
         )
     }

--- a/crates/vox-storage/src/text.rs
+++ b/crates/vox-storage/src/text.rs
@@ -135,6 +135,7 @@ mod tests {
                 diarization_mode: "none".to_owned(),
                 decoding_strategy: String::new(),
                 initial_prompt: String::new(),
+                condition_on_previous_text: false,
             },
         )
     }

--- a/crates/vox-transcribe/src/whisper.rs
+++ b/crates/vox-transcribe/src/whisper.rs
@@ -222,6 +222,12 @@ impl WhisperTranscriber {
             params.set_initial_prompt(&sanitized);
         }
 
+        // Break decode-repetition loops: by default, do not feed previously
+        // generated text forward as the prompt for the next internal window.
+        // A hallucinated phrase over a silent stretch would otherwise prime the
+        // next window and self-perpetuate (see `condition_on_previous_text`).
+        params.set_no_context(!self.config.condition_on_previous_text);
+
         // We want the original speech, not an English translation.
         params.set_translate(false);
 

--- a/vox-daemon/src/daemon.rs
+++ b/vox-daemon/src/daemon.rs
@@ -429,6 +429,7 @@ mod tests {
             diarization_mode: cfg.transcription.diarization_mode.clone(),
             decoding_strategy: cfg.transcription.decoding_strategy.clone(),
             initial_prompt: cfg.transcription.initial_prompt.clone(),
+            condition_on_previous_text: cfg.transcription.condition_on_previous_text,
         };
         Session::new(sources, snap)
     }

--- a/vox-daemon/src/main.rs
+++ b/vox-daemon/src/main.rs
@@ -16,6 +16,7 @@ mod audio_save;
 mod daemon;
 mod logging;
 mod recording;
+mod transcript_postprocess;
 
 /// Vox Daemon — Capture, transcribe, and summarize video call audio on Linux.
 #[derive(Parser)]

--- a/vox-daemon/src/recording.rs
+++ b/vox-daemon/src/recording.rs
@@ -10,6 +10,7 @@ use vox_capture::{AudioChunk, AudioSource, StreamRole};
 use vox_core::config::AppConfig;
 use vox_core::session::{
     AudioRole, AudioSourceInfo, ConfigSnapshot, Session, SpeakerMapping, SpeakerSource,
+    TranscriptSegment,
 };
 use vox_storage::{JsonFileStore, SessionStore};
 use vox_transcribe::{AudioSourceRole, Transcriber, TranscriptionRequest};
@@ -272,6 +273,7 @@ fn build_session(config: &AppConfig, mic_samples: usize, app_samples: usize) -> 
         diarization_mode: config.transcription.diarization_mode.clone(),
         decoding_strategy: config.transcription.decoding_strategy.clone(),
         initial_prompt: config.transcription.initial_prompt.clone(),
+        condition_on_previous_text: config.transcription.condition_on_previous_text,
     };
 
     let mut session = Session::new(audio_sources, config_snapshot);
@@ -416,6 +418,43 @@ fn resolve_source(setting: &str, streams: &[vox_capture::StreamInfo], is_mic: bo
     }
 }
 
+/// Window length for chunked transcription, in samples at 16 kHz.
+///
+/// 30 s matches Whisper's native internal context window, so windows cut on a
+/// natural boundary. `30 s * 16_000 Hz = 480_000 samples`.
+const TRANSCRIBE_WINDOW_SAMPLES: usize = 30 * 16_000;
+
+/// Transcribe a long audio buffer as independent fixed ~30 s windows, offsetting
+/// each onto the global timeline via [`TranscriptionRequest::with_offset`], and
+/// concatenating the resulting segments.
+///
+/// Processing per-window (rather than handing the whole recording to Whisper in
+/// one call) has two structural benefits against decode-repetition loops:
+/// - the energy gate inside [`Transcriber::transcribe`] drops silent windows
+///   individually, so long dead-air stretches never seed a hallucination, and
+/// - any decode loop that does start is bounded to a single 30 s window instead
+///   of running away across the entire recording.
+fn transcribe_windowed<T: Transcriber>(
+    transcriber: &T,
+    audio: &[f32],
+) -> Result<Vec<TranscriptSegment>> {
+    let mut segments = Vec::new();
+    for (i, window) in audio.chunks(TRANSCRIBE_WINDOW_SAMPLES).enumerate() {
+        #[allow(clippy::cast_precision_loss)]
+        let offset_secs = (i * TRANSCRIBE_WINDOW_SAMPLES) as f64 / 16_000.0;
+        let request = TranscriptionRequest::with_offset(
+            window.to_vec(),
+            AudioSourceRole::Merged,
+            offset_secs,
+        );
+        let result = transcriber
+            .transcribe(&request)
+            .map_err(|e| anyhow::anyhow!("transcription failed: {e}"))?;
+        segments.extend(result.segments);
+    }
+    Ok(segments)
+}
+
 /// Transcribe audio chunks into the session transcript.
 ///
 /// When `diarization_mode` is `"none"` (default), both streams are merged
@@ -463,13 +502,15 @@ fn transcribe_audio(
         merged_duration
     );
 
-    let request = TranscriptionRequest::new(merged.clone(), AudioSourceRole::Merged);
-    let result = transcriber
-        .transcribe(&request)
-        .map_err(|e| anyhow::anyhow!("transcription failed: {e}"))?;
+    let mut segments = transcribe_windowed(&transcriber, &merged)?;
+    tracing::info!("transcription produced {} segments", segments.len());
 
-    tracing::info!("transcription produced {} segments", result.segments.len());
-    session.transcript = result.segments;
+    // Collapse any residual decode-repetition runs before diarization/storage.
+    segments = crate::transcript_postprocess::collapse_repeated_segments(
+        segments,
+        config.transcription.repeat_collapse_threshold,
+    );
+    session.transcript = segments;
 
     // Run speaker diarization if configured and available.
     #[cfg(feature = "diarize")]
@@ -645,12 +686,12 @@ pub fn reprocess_session(config: &AppConfig, session_id: &str) -> Result<()> {
     #[cfg(not(feature = "whisper"))]
     let transcriber = vox_transcribe::StubTranscriber::new();
 
-    let request = TranscriptionRequest::new(samples.clone(), AudioSourceRole::Merged);
-    let result = transcriber
-        .transcribe(&request)
-        .map_err(|e| anyhow::anyhow!("transcription failed: {e}"))?;
-
-    session.transcript = result.segments;
+    let mut segments = transcribe_windowed(&transcriber, &samples)?;
+    segments = crate::transcript_postprocess::collapse_repeated_segments(
+        segments,
+        config.transcription.repeat_collapse_threshold,
+    );
+    session.transcript = segments;
 
     // Re-run diarization if configured.
     #[cfg(feature = "diarize")]
@@ -673,6 +714,7 @@ pub fn reprocess_session(config: &AppConfig, session_id: &str) -> Result<()> {
         diarization_mode: config.transcription.diarization_mode.clone(),
         decoding_strategy: config.transcription.decoding_strategy.clone(),
         initial_prompt: config.transcription.initial_prompt.clone(),
+        condition_on_previous_text: config.transcription.condition_on_previous_text,
     };
 
     store
@@ -687,4 +729,46 @@ pub fn reprocess_session(config: &AppConfig, session_id: &str) -> Result<()> {
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vox_transcribe::{TranscribeError, TranscriptionResult};
+
+    /// Mock transcriber emitting exactly one segment per call, echoing the
+    /// request's time offset into the segment timing so the windowing logic can
+    /// be verified without a real model.
+    struct OffsetEchoTranscriber;
+
+    impl Transcriber for OffsetEchoTranscriber {
+        fn transcribe(
+            &self,
+            request: &TranscriptionRequest,
+        ) -> std::result::Result<TranscriptionResult, TranscribeError> {
+            let offset = request.time_offset_secs;
+            Ok(TranscriptionResult::new(vec![TranscriptSegment {
+                start_time: offset,
+                end_time: offset + 1.0,
+                speaker: "Speaker".to_owned(),
+                text: format!("window@{offset}"),
+            }]))
+        }
+    }
+
+    #[test]
+    fn windows_audio_and_offsets_each_window() {
+        // 75 s of audio at 16 kHz → 3 windows (30 + 30 + 15 s).
+        let audio = vec![0.1_f32; 75 * 16_000];
+        let segments = transcribe_windowed(&OffsetEchoTranscriber, &audio).expect("transcribe");
+        let offsets: Vec<f64> = segments.iter().map(|s| s.start_time).collect();
+        assert_eq!(offsets, vec![0.0, 30.0, 60.0]);
+        assert_eq!(segments.len(), 3);
+    }
+
+    #[test]
+    fn empty_audio_produces_no_segments() {
+        let segments = transcribe_windowed(&OffsetEchoTranscriber, &[]).expect("transcribe");
+        assert!(segments.is_empty());
+    }
 }

--- a/vox-daemon/src/transcript_postprocess.rs
+++ b/vox-daemon/src/transcript_postprocess.rs
@@ -1,0 +1,159 @@
+//! Post-processing transforms applied to a transcript after inference.
+//!
+//! These operate on the chronological `Vec<TranscriptSegment>` produced by the
+//! transcription stage, before diarization and timeline sorting.
+
+use vox_core::session::TranscriptSegment;
+
+/// Collapse runs of `threshold` or more consecutive segments with identical
+/// speaker **and** text down to their first occurrence, discarding the rest.
+///
+/// This is a backstop for Whisper decode-repetition loops, where the model
+/// emits the same phrase dozens or hundreds of times in lockstep over a silent
+/// or low-quality stretch. Genuine short repeats (a word said twice) fall below
+/// the threshold and are left untouched.
+///
+/// Only the **first** segment of a collapsed run is kept, preserving its
+/// original (short) timestamps rather than fabricating one segment that spans
+/// the entire run. The number of dropped segments is logged at `warn` level so
+/// the collapse is never silent.
+///
+/// A `threshold` of `0` or `1` disables collapsing and returns the input
+/// unchanged. The input must be in chronological order (as produced by
+/// transcription) for runs to be detected correctly.
+#[must_use]
+pub fn collapse_repeated_segments(
+    segments: Vec<TranscriptSegment>,
+    threshold: usize,
+) -> Vec<TranscriptSegment> {
+    if threshold < 2 || segments.len() < threshold {
+        return segments;
+    }
+
+    let mut out: Vec<TranscriptSegment> = Vec::with_capacity(segments.len());
+    let mut dropped = 0usize;
+    let mut i = 0;
+    while i < segments.len() {
+        // Find the end of the maximal run of identical (speaker, text).
+        let mut j = i + 1;
+        while j < segments.len()
+            && segments[j].text == segments[i].text
+            && segments[j].speaker == segments[i].speaker
+        {
+            j += 1;
+        }
+        let run_len = j - i;
+        if run_len >= threshold {
+            // Keep only the first occurrence of the run.
+            out.push(segments[i].clone());
+            dropped += run_len - 1;
+        } else {
+            out.extend_from_slice(&segments[i..j]);
+        }
+        i = j;
+    }
+
+    if dropped > 0 {
+        tracing::warn!(
+            dropped,
+            threshold,
+            "collapsed repeated transcript segments (decode-loop hallucination guard)"
+        );
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a segment with the given timing and text under a fixed speaker.
+    fn seg(start: f64, end: f64, text: &str) -> TranscriptSegment {
+        TranscriptSegment {
+            start_time: start,
+            end_time: end,
+            speaker: "Speaker".to_owned(),
+            text: text.to_owned(),
+        }
+    }
+
+    fn texts(segs: &[TranscriptSegment]) -> Vec<&str> {
+        segs.iter().map(|s| s.text.as_str()).collect()
+    }
+
+    #[test]
+    fn collapses_long_run_to_first_occurrence() {
+        let input = vec![
+            seg(0.0, 1.0, "hello"),
+            seg(2.0, 4.0, "loop"),
+            seg(4.0, 6.0, "loop"),
+            seg(6.0, 8.0, "loop"),
+            seg(8.0, 10.0, "loop"),
+            seg(8.0, 10.0, "loop"),
+            seg(10.0, 11.0, "bye"),
+        ];
+        let out = collapse_repeated_segments(input, 3);
+        assert_eq!(texts(&out), vec!["hello", "loop", "bye"]);
+        // First occurrence of the run keeps its original (short) timestamps.
+        let kept = &out[1];
+        assert!((kept.start_time - 2.0).abs() < f64::EPSILON);
+        assert!((kept.end_time - 4.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn preserves_run_below_threshold() {
+        // A double ("yeah. yeah.") is genuine speech, not a loop.
+        let input = vec![
+            seg(0.0, 1.0, "yeah"),
+            seg(1.0, 2.0, "yeah"),
+            seg(2.0, 3.0, "okay"),
+        ];
+        let out = collapse_repeated_segments(input, 3);
+        assert_eq!(texts(&out), vec!["yeah", "yeah", "okay"]);
+    }
+
+    #[test]
+    fn different_speaker_breaks_a_run() {
+        let mut a = seg(0.0, 2.0, "loop");
+        a.speaker = "You".to_owned();
+        let mut b = seg(2.0, 4.0, "loop");
+        b.speaker = "Remote".to_owned();
+        let mut c = seg(4.0, 6.0, "loop");
+        c.speaker = "Remote".to_owned();
+        // [You/loop, Remote/loop, Remote/loop] — the Remote run is only 2 long.
+        let out = collapse_repeated_segments(vec![a, b, c], 3);
+        assert_eq!(out.len(), 3);
+    }
+
+    #[test]
+    fn collapses_multiple_independent_runs() {
+        let input = vec![
+            seg(0.0, 1.0, "a"),
+            seg(1.0, 2.0, "a"),
+            seg(2.0, 3.0, "a"),
+            seg(3.0, 4.0, "b"),
+            seg(4.0, 5.0, "c"),
+            seg(5.0, 6.0, "c"),
+            seg(6.0, 7.0, "c"),
+        ];
+        let out = collapse_repeated_segments(input, 3);
+        assert_eq!(texts(&out), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn threshold_zero_or_one_disables() {
+        let input = vec![seg(0.0, 1.0, "x"), seg(1.0, 2.0, "x"), seg(2.0, 3.0, "x")];
+        let out0 = collapse_repeated_segments(input.clone(), 0);
+        assert_eq!(out0.len(), 3);
+        let out1 = collapse_repeated_segments(input, 1);
+        assert_eq!(out1.len(), 3);
+    }
+
+    #[test]
+    fn handles_empty_and_single() {
+        assert!(collapse_repeated_segments(Vec::new(), 3).is_empty());
+        let single = vec![seg(0.0, 1.0, "x")];
+        assert_eq!(collapse_repeated_segments(single, 3).len(), 1);
+    }
+}


### PR DESCRIPTION
## Problem

Long sessions contained huge runs of the **same sentence repeated in lockstep** — e.g. in session `cc59e492` the phrase *"I think you can make it a good user experience."* appears **676×** across 22 minutes (2122s–3485s), each segment exactly 2.0s with a 2.0s step. A second run repeated *"I think it's a great thing."* 374×. This is not a storage-duplication bug; it's a Whisper **decode-repetition loop**.

### Root cause
1. **The entire recording was transcribed in one `state.full()` call** over the merged buffer (~58 min). Whisper conditions each internal 30s window on the text it just generated, so a phrase hallucinated over a silent/low-quality stretch primes the next window and self-perpetuates indefinitely.
2. **No configured guard catches it.** `entropy_thold`/`logprob_thold` only trigger temperature fallback for *low-confidence* output; a confident repetition loop has *low* entropy and *high* logprob. whisper.cpp has no compression-ratio guard, and `set_no_context()` was never called. The whole-buffer energy gate can't help because 58 min of mostly-speech passes it, leaving silent inner stretches ungated.

## Fix (three composing layers)

1. **`set_no_context(true)` by default** in `build_params` — generated text no longer primes the next window. Exposed as `condition_on_previous_text` (default `false`) as an escape hatch.
2. **`transcribe_windowed()`** — split the merged buffer into fixed 30s windows and transcribe each independently with a timeline offset (reusing `TranscriptionRequest::with_offset`). Per-window inference means the existing in-`transcribe` energy gate drops silent windows individually, and any loop is bounded to a single window. Applied to **both** `transcribe_audio` and `reprocess_session`.
3. **`collapse_repeated_segments()`** — post-process backstop collapsing runs of N+ consecutive identical segments to their first occurrence (preserving its original short timestamps). Configurable via `repeat_collapse_threshold` (default 3, 0/1 disables); warns how many were dropped.

How they compose: the 22-min dead-air stretch splits into ~44 windows, each below the RMS gate → skipped, so the loop never starts (#2); a within-window loop can't prime the next window (#1); any residue ≤ one window's worth is collapsed (#3).

## New config (`TranscriptionConfig`)
- `condition_on_previous_text: bool` (default `false`)
- `repeat_collapse_threshold: usize` (default `3`)

## Tests
- `transcript_postprocess`: run collapse, sub-threshold preservation, speaker-boundary breaks, multiple runs, disable, empty/single.
- `recording`: windowing offsets/concatenation via a mock `Transcriber`; empty audio → no segments.

## Verification
- `cargo fmt --all --check` ✓
- `cargo test -p vox-core -p vox-daemon -p vox-storage -p vox-gui` ✓ (new tests pass)
- `cargo clippy -p vox-core -p vox-daemon -p vox-storage --all-targets -- -W clippy::all -W clippy::pedantic` ✓ clean
- `cargo check -p vox-transcribe --features whisper` ✓ (`set_no_context` valid in whisper-rs 0.15.1)

## Follow-up (not in this PR)
VAD/silence-aware windowing to remove fixed-window word-boundary clipping — deferred; no silence-detection utility exists yet and it isn't required for the loop fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)